### PR TITLE
Fix problem with exporting types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
     "name": "@guardian/atoms-rendering",
     "source": "src/index.ts",
-    "main": "dist/app.js",
-    "module": "dist/app.module.js",
-    "unpkg": "dist/app.umd.js",
+    "main": "dist/index.js",
+    "module": "dist/index.module.js",
+    "unpkg": "dist/index.umd.js",
     "publishConfig": {
         "access": "public"
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
         "target": "esnext",
         "module": "esnext",
         "lib": ["es2017", "es7", "es6", "dom", "DOM.Iterable"],
-        "outDir": "build",
+        "outDir": "dist",
         "strict": true,
         "esModuleInterop": true,
         "jsx": "react",


### PR DESCRIPTION
Rename app > index and the build folder is called 'dist', not 'build'