### PR TITLE
Use modern build for module

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "1.2.2",
     "source": "src/index.ts",
     "main": "dist/index.js",
-    "module": "dist/index.module.js",
+    "module": "dist/index.modern.js",
     "unpkg": "dist/index.umd.js",
     "publishConfig": {
         "access": "public"


### PR DESCRIPTION
Replace `index.module.js` with `index.modern.js` to ensure we always have the latest and smallest build