### PR TITLE
Explainer styles

### DIFF
--- a/src/ExplainerAtom.tsx
+++ b/src/ExplainerAtom.tsx
@@ -23,8 +23,8 @@ const Container = ({
                 padding-left: ${space[2]}px;
                 padding-right: ${space[2]}px;
                 border-top: 1px solid ${text.primary};
-                background-color: ${background.secondary};
                 color: ${text.primary};
+                background: ${background.secondary};
 
                 p {
                     margin-top: ${space[3]}px;

--- a/src/ExplainerAtom.tsx
+++ b/src/ExplainerAtom.tsx
@@ -25,6 +25,11 @@ const Container = ({
                 border-top: 1px solid ${text.primary};
                 background-color: ${background.secondary};
                 color: ${text.primary};
+
+                p {
+                    margin-top: ${space[3]}px;
+                    margin-bottom: ${space[3]}px;
+                }
             `}
         >
             {children}


### PR DESCRIPTION
In DCR we override p tag spacing so we need to explicitly set it here.

We're also not seeing the `background` color come through so I'm moving it below `color` here.