### PR TITLE
remove margin on explainer atom figure

### DIFF
--- a/src/ExplainerAtom.tsx
+++ b/src/ExplainerAtom.tsx
@@ -22,6 +22,7 @@ const Container = ({
                 padding-bottom: ${space[1]}px;
                 padding-left: ${space[2]}px;
                 padding-right: ${space[2]}px;
+                margin: auto 0;
                 border-top: 1px solid ${text.primary};
                 color: ${text.primary};
                 background: ${neutral[97]};


### PR DESCRIPTION
Would this work for DCR? it would be useful if atoms came without side padding/margin for AR.

[apps-rendering pull request](https://github.com/guardian/apps-rendering/pull/370)

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/84022861-ea4b5380-a97e-11ea-930f-7bb3b59b0645.png" width="300" />  | <img src="https://user-images.githubusercontent.com/11618797/84022873-f33c2500-a97e-11ea-8381-11f690f3495b.png" width="300" />  |
