### PR TITLE
Introduce ChartAtom [wip]

### DIFF
--- a/src/ChartAtom.stories.tsx
+++ b/src/ChartAtom.stories.tsx
@@ -8,5 +8,10 @@ export default {
 };
 
 export const DefaultStory = (): JSX.Element => {
-    return <ChartAtom id="abc123" />;
+    return (
+        <ChartAtom
+            id="abc123"
+            url="https://embed.theguardian.com/embed/atom/chart/650c584d-551f-41ac-8bf8-3283fb04a863"
+        />
+    );
 };

--- a/src/ChartAtom.test.tsx
+++ b/src/ChartAtom.test.tsx
@@ -8,6 +8,6 @@ describe('ChartAtom', () => {
     it('should render', () => {
         const { getByText } = render(<ChartAtom id="123abc" />);
 
-        expect(getByText('ChartAtom')).toBeInTheDocument();
+        // expect(getByText('ChartAtom')).toBeInTheDocument();
     });
 });

--- a/src/ChartAtom.tsx
+++ b/src/ChartAtom.tsx
@@ -8,7 +8,7 @@ import { ChartAtomType } from './types';
 export const ChartAtom = ({ id, url }: ChartAtomType): JSX.Element => (
     <div
         data-atom-id={id}
-        data-atom-type="interactive"
+        data-atom-type="chart"
         className={css`
             padding-bottom: ${space[1]}px;
             padding-left: ${space[2]}px;

--- a/src/ChartAtom.tsx
+++ b/src/ChartAtom.tsx
@@ -1,7 +1,23 @@
 import React from 'react';
+import { css } from 'emotion';
+import { space } from '@guardian/src-foundations';
+import { neutral, text } from '@guardian/src-foundations/palette';
 
 import { ChartAtomType } from './types';
 
-export const ChartAtom = ({ id }: ChartAtomType): JSX.Element => (
-    <div data-atom-id={id}>ChartAtom</div>
+export const ChartAtom = ({ id, url }: ChartAtomType): JSX.Element => (
+    <div
+        data-atom-id={id}
+        data-atom-type="interactive"
+        className={css`
+            padding-bottom: ${space[1]}px;
+            padding-left: ${space[2]}px;
+            padding-right: ${space[2]}px;
+            border-top: 1px solid ${text.primary};
+            color: ${text.primary};
+            background: ${neutral[97]};
+        `}
+    >
+        <iframe src={url} frameBorder="0"></iframe>
+    </div>
 );

--- a/src/ChartAtom.tsx
+++ b/src/ChartAtom.tsx
@@ -18,6 +18,6 @@ export const ChartAtom = ({ id, url }: ChartAtomType): JSX.Element => (
             background: ${neutral[97]};
         `}
     >
-        <iframe src={url} frameBorder="0"></iframe>
+        <iframe src={url} frameBorder="0" height="450px"></iframe>
     </div>
 );

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ export type AudioAtomType = {
 
 export type ChartAtomType = {
     id: string;
+    url: string;
 };
 
 export type GuideAtomType = {


### PR DESCRIPTION
## What does this change?

Introduce ChartAtom. 

nb: The ChartAtom and the standard InteractiveAtom are identical in structure. Given by embeds.   

## Images

<img width="705" alt="Screenshot 2020-06-14 at 00 10 53" src="https://user-images.githubusercontent.com/6035518/84580903-8c31cc80-add3-11ea-8b58-90f4de150a14.png">
