### PR TITLE
Remove iframe styles other than full width

### DIFF
--- a/src/InteractiveAtom.tsx
+++ b/src/InteractiveAtom.tsx
@@ -15,13 +15,6 @@ const fullWidthStyles = css`
     width: 100%;
 `;
 
-const iframeStyles = css`
-    padding-bottom: ${space[1]}px;
-    padding-left: ${space[2]}px;
-    padding-right: ${space[2]}px;
-    color: ${text.primary};
-`;
-
 export const InteractiveAtom = ({
     id,
     html,
@@ -34,7 +27,7 @@ export const InteractiveAtom = ({
         data-atom-type="interactive"
     >
         <iframe
-            className={cx(fullWidthStyles, iframeStyles)}
+            className={fullWidthStyles}
             srcDoc={unifyPageContent({ js, css, html })}
             frameBorder="0"
         />


### PR DESCRIPTION
This matches Frontend's styles for the interactive atom iframe

Removes the extra padding, because that was causing an issue with some interactive atoms

## Before

![Screen Shot 2020-07-30 at 13 09 20](https://user-images.githubusercontent.com/638051/88921239-163fd280-d266-11ea-9bd0-a9b859c9140d.png)



## After

![Screen Shot 2020-07-30 at 13 09 10](https://user-images.githubusercontent.com/638051/88921244-18a22c80-d266-11ea-8128-c347c2f56d02.png)
