### PR TITLE
1.5.0 Version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "@babel/preset-react": "^7.9.4",
         "@babel/preset-typescript": "^7.9.0",
         "@guardian/src-foundations": "^1.0.1",
-        "@guardian/src-icons": "1.9.1",
+        "@guardian/src-icons": "^1.9.1",
         "@storybook/addons": "^5.3.19",
         "@storybook/preset-typescript": "^3.0.0",
         "@storybook/react": "^5.3.19",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "@babel/preset-react": "^7.9.4",
         "@babel/preset-typescript": "^7.9.0",
         "@guardian/src-foundations": "^1.0.1",
+        "@guardian/src-icons": "1.9.1",
         "@storybook/addons": "^5.3.19",
         "@storybook/preset-typescript": "^3.0.0",
         "@storybook/react": "^5.3.19",
@@ -73,7 +74,7 @@
     },
     "peerDependencies": {
         "@guardian/src-foundations": "^1.1.0",
-        "@guardian/src-icons": "^2.0.0",
+        "@guardian/src-icons": "1.9.1",
         "emotion": "^10.0.27",
         "react": "^16.13.1",
         "react-dom": "^16.13.1"
@@ -83,8 +84,5 @@
         "moduleNameMapper": {
             "^@guardian/src-foundations/(.*)$": "@guardian/src-foundations/$1/cjs"
         }
-    },
-    "dependencies": {
-        "@guardian/src-icons": "1.9.1"
     }
 }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     },
     "peerDependencies": {
         "@guardian/src-foundations": "^1.1.0",
-        "@guardian/src-icons": "1.9.1",
+        "@guardian/src-icons": "^1.9.1",
         "emotion": "^10.0.27",
         "react": "^16.13.1",
         "react-dom": "^16.13.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@guardian/atoms-rendering",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "source": "src/index.ts",
     "main": "dist/index.js",
     "module": "dist/index.modern.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@guardian/atoms-rendering",
-    "version": "1.3.5",
+    "version": "1.4.0",
     "source": "src/index.ts",
     "main": "dist/index.js",
     "module": "dist/index.modern.js",

--- a/package.json
+++ b/package.json
@@ -83,5 +83,8 @@
         "moduleNameMapper": {
             "^@guardian/src-foundations/(.*)$": "@guardian/src-foundations/$1/cjs"
         }
+    },
+    "dependencies": {
+        "@guardian/src-icons": "1.9.1"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1097,10 +1097,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-1.1.0.tgz#1955a3933c3aecfae46d4688a43f331866386b94"
   integrity sha512-XGZSbHuHf20kewajdIAOPk7jb6mB6+wPYFj+CUuKcEPXXjNLQ4K5WVIzu0xQ9Fa5aO1wG/s0ek0ii9KbpDcbNA==
 
-"@guardian/src-icons@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-icons/-/src-icons-2.0.0.tgz#040512320b2c297a9fb2e98d159e4cc368a6cbcf"
-  integrity sha512-6F7DwPOeltgkR20yNQ+bJObHwxe5VKsZVOgYewaLoJB8LEdfVaF96DHr+WCeMUS5nV38oa7dMqdlnnPoih4CBg==
+"@guardian/src-icons@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-icons/-/src-icons-1.9.1.tgz#86d9dba8085042014e5851db8b2388ff2a25c201"
+  integrity sha512-wdLFDoE8qvKxRyb3EjTBvErMxsYpsckrb/2eRtEjqm4dP2nycK51qTyhLS9aJXvILQnlZLKg5yVbxKdYQokEgQ==
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1097,7 +1097,7 @@
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-1.1.0.tgz#1955a3933c3aecfae46d4688a43f331866386b94"
   integrity sha512-XGZSbHuHf20kewajdIAOPk7jb6mB6+wPYFj+CUuKcEPXXjNLQ4K5WVIzu0xQ9Fa5aO1wG/s0ek0ii9KbpDcbNA==
 
-"@guardian/src-icons@1.9.1":
+"@guardian/src-icons@^1.9.1":
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/@guardian/src-icons/-/src-icons-1.9.1.tgz#86d9dba8085042014e5851db8b2388ff2a25c201"
   integrity sha512-wdLFDoE8qvKxRyb3EjTBvErMxsYpsckrb/2eRtEjqm4dP2nycK51qTyhLS9aJXvILQnlZLKg5yVbxKdYQokEgQ==


### PR DESCRIPTION
## What does this change?

This is the basis for atoms-rendering version 1.5.0. This version now includes Q and A atoms

