### PR TITLE
Bump to 1.7.0 - Timeline Atoms

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@guardian/atoms-rendering",
-    "version": "1.6.0",
+    "version": "1.7.0",
     "source": "src/index.ts",
     "main": "dist/index.js",
     "module": "dist/index.modern.js",


### PR DESCRIPTION
## What does this change?
Bump the atoms-rendering package to 1.7.0, which now includes timelines



