### PR TITLE
Version bump to 1.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@guardian/atoms-rendering",
-    "version": "1.8.0",
+    "version": "1.8.1",
     "source": "src/index.ts",
     "main": "dist/index.js",
     "module": "dist/index.modern.js",


### PR DESCRIPTION
## What does this change?
This bumps the version to include refactoring of the Q&A and Guide atoms.