### PR TITLE
Fix emotion console warnings

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -4,6 +4,14 @@ module.exports = {
         '@babel/preset-typescript',
         '@babel/preset-react',
     ],
+    plugins: [
+        [
+            'emotion',
+            {
+                sourceMap: false,
+            },
+        ],
+    ],
     env: {
         test: {
             plugins: ['@babel/plugin-transform-runtime'],

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
         "@typescript-eslint/eslint-plugin": "^3.0.1",
         "@typescript-eslint/parser": "^3.0.1",
         "babel-loader": "^8.1.0",
+        "babel-plugin-emotion": "^10.0.33",
         "chromatic": "^5.0.0",
         "emotion": "^10.0.27",
         "eslint": "^7.1.0",


### PR DESCRIPTION
## What does this change?
This should remove emotion warnings in the console when running DCR locally. The errors were: 

`You have illegal escape sequence in your template literal, most likely inside content's property value. Because you write your CSS inside a JavaScript string you actually have to do double escaping, so for example "content: '\00d7';" should become "content: '\\00d7';". You can read more about this here:`

The sourceMap flag has been disabled in dev-mode in atoms-rendering.
