### PR TITLE
Add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## Why?

Keeps dependencies up-to-date! For example I noticed that this repo is still on Source v1, and Dependabot has been useful on other projects (AR, DCR, etc.) for keeping Source updated.

These changes are based on the PRs to add this to [AR](https://github.com/guardian/apps-rendering/pull/393) and the [mobile templates](https://github.com/guardian/mobile-apps-article-templates/pull/1186).

## Changes

- Added `dependabot.yml`
