### PR TITLE
Update README for moving default branch to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ import { TheAtomYouWant } from '@guardian/atoms-rendering';
 <TheAtomYouWant someProp={localData.someProp} />
 ```
 
+## Moving to main
+
+The `master` branch in the frontend repository has now been renamed to `main`. If you have been working with this repository before the change, then run the following sequence of commands.
+
+```
+git fetch --all
+git remote set-head origin -a
+git branch master --set-upstream-to origin/main
+git branch -m master main
+```
+
+
 ## Running locally
 
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ import { TheAtomYouWant } from '@guardian/atoms-rendering';
 
 ## Moving to main
 
-The `master` branch in the frontend repository has now been renamed to `main`. If you have been working with this repository before the change, then run the following sequence of commands.
+The `master` branch in the atoms-rendering repository has now been renamed to `main`. If you have been working with this repository before the change, then run the following sequence of commands.
 
 ```
 git fetch --all


### PR DESCRIPTION
Add instruction to move the default branch from `master` to `main`.
