### PR TITLE
Document the renaming of the Media atom

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ import { TheAtomYouWant } from '@guardian/atoms-rendering';
 
 ### Naming conventions
 
-There is mostly a one to one correspondance between atom as named by CAPI/frontend and their names in atoms-rendering, with the notable exception that the Media atom is named YoutubeAtom here. 
+There is mostly a one to one correspondance between atoms as named by CAPI/frontend and their names in atoms-rendering, with the notable exception that the Media atom is named YoutubeAtom here. 
 
 ## Moving to main
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ An Atom is a self contained piece of content that can be inserted into multiple 
 
 ## Usage
 
+### import 
+
 To import an atom in your project use `yarn add @guardian/atoms-rendering` then
 
 ```
@@ -13,6 +15,10 @@ import { TheAtomYouWant } from '@guardian/atoms-rendering';
 
 <TheAtomYouWant someProp={localData.someProp} />
 ```
+
+### Naming conventions
+
+There is mostly a one to one correspondance between atom as named by CAPI/frontend and their names in atoms-rendering, with the notable exception that the Media atom is named YoutubeAtom here. 
 
 ## Moving to main
 


### PR DESCRIPTION
## What does this change?

Update the README to document the renaming of the Media atom to YoutubeAtom.