### PR TITLE
add explicit color style to detail element

### DIFF
--- a/src/expandableAtom/Container.tsx
+++ b/src/expandableAtom/Container.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { css } from 'emotion';
-import { neutral } from '@guardian/src-foundations/palette';
+import { neutral, text } from '@guardian/src-foundations/palette';
 import { Summary } from './Summary';
 
 const containerStyling = css`
@@ -13,6 +13,7 @@ const containerStyling = css`
 const detailStyling = css`
     margin: 16px 0 36px;
     background: ${neutral[93]};
+    color: ${text.primary};
     padding: 0 5px 6px;
     border-image: repeating-linear-gradient(
             to bottom,


### PR DESCRIPTION
## What does this change?
Sets an explicit color style on the details element in the expandableAtom component instead of relying on outside page styles.
This would match the `ExplainerAtom` component https://github.com/guardian/atoms-rendering/blob/main/src/ExplainerAtom.tsx#L26

Without setting this color in the atom styles, we have some problems in dark mode on apps (screenshots below).

## How to test

## How can we measure success?
Users should see no difference.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

apps-rendering dark mode.

| Before | After |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/11618797/92597593-89922680-f29f-11ea-97ae-edcc3504bf8f.png" width="300" /> | <img src="https://user-images.githubusercontent.com/11618797/92597822-d4ac3980-f29f-11ea-8289-141aa5b0a56a.png" width="300" /> |