### PR TITLE
Fix const enums

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
         "allowSyntheticDefaultImports": true,
         "forceConsistentCasingInFileNames": true,
         "resolveJsonModule": true,
-        "isolatedModules": true,
+        "isolatedModules": false,
         "noEmit": true
     },
     "files": ["src/types.ts"],


### PR DESCRIPTION
Note: https://github.com/guardian/dotcom-rendering/pull/1900 is related and includes some necessary changes there to also fix const enum support. That PR depends on this one.

## What does this change?

isolatedModules breaks some features, including const enums, that are used by @guardian/types. Let's enable it so that the transpiled code works for DCR and others.

## How to test

`yarn link` and try using the `YoutubeAtom` in DCR for example, both on main and this branch. With main you will get an undefined error at runtime.
