### PR TITLE
Remove gu-script from chart-atom

### DIFF
--- a/src/ChartAtom.tsx
+++ b/src/ChartAtom.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { css } from 'emotion';
 import { space } from '@guardian/src-foundations';
-import { text } from '@guardian/src-foundations/palette';
 
 import { ChartAtomType } from './types';
 

--- a/src/ChartAtom.tsx
+++ b/src/ChartAtom.tsx
@@ -9,11 +9,6 @@ export const ChartAtom = ({ id, url, html }: ChartAtomType): JSX.Element => {
     // The script tag needs to replaced with 'gu-script' to work with iframe
     // resizing on frontend
 
-    html = html
-        .split('<script>')
-        .join('<gu-script>')
-        .split('</script>')
-        .join('</gu-script>');
     return (
         <div
             data-atom-id={id}


### PR DESCRIPTION
Minor change, removes the gu-script tag from chart-atoms as resizing now works without it.
