### PR TITLE
Simplify the props of ChartAtom

### DIFF
--- a/src/ChartAtom.stories.tsx
+++ b/src/ChartAtom.stories.tsx
@@ -15,11 +15,5 @@ export const DefaultStory = (): JSX.Element => {
         atomResizer();
         atomGuScriptSwap();
     }, []);
-    return (
-        <ChartAtom
-            id="abc123"
-            url="https://embed.theguardian.com/embed/atom/chart/650c584d-551f-41ac-8bf8-3283fb04a863"
-            html={html}
-        />
-    );
+    return <ChartAtom id="abc123" html={html} />;
 };

--- a/src/ChartAtom.test.tsx
+++ b/src/ChartAtom.test.tsx
@@ -7,13 +7,7 @@ import { ChartAtom } from './ChartAtom';
 
 describe('ChartAtom', () => {
     it('should render', () => {
-        const { getByTestId } = render(
-            <ChartAtom
-                url="https://api.nextgen.guardianapps.co.uk/embed/atom/chart/16597f9d-cc9c-4659-bfcb-1a1fcbbf6263"
-                id="123abc"
-                html={html}
-            />,
-        );
+        const { getByTestId } = render(<ChartAtom id="123abc" html={html} />);
 
         expect(getByTestId('chart')).toBeInTheDocument();
     });

--- a/src/ChartAtom.tsx
+++ b/src/ChartAtom.tsx
@@ -4,7 +4,7 @@ import { space } from '@guardian/src-foundations';
 
 import { ChartAtomType } from './types';
 
-export const ChartAtom = ({ id, url, html }: ChartAtomType): JSX.Element => {
+export const ChartAtom = ({ id, html }: ChartAtomType): JSX.Element => {
     return (
         <div
             data-atom-id={id}

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,6 @@ export type AudioAtomType = {
 
 export type ChartAtomType = {
     id: string;
-    url: string;
     html: string;
 };
 


### PR DESCRIPTION
## What does this change?

Simplify the props of ChartAtom. (The `url` is not needed).