### PR TITLE
update src packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
         "@babel/plugin-transform-runtime": "^7.9.6",
         "@babel/preset-react": "^7.10.4",
         "@babel/preset-typescript": "^7.9.0",
-        "@guardian/src-foundations": "^1.0.1",
-        "@guardian/src-icons": "^1.9.1",
+        "@guardian/src-foundations": "^2.4.0",
+        "@guardian/src-icons": "^2.4.0",
         "@guardian/types": "^0.4.4",
         "@storybook/addons": "^5.3.19",
         "@storybook/preset-typescript": "^3.0.0",
@@ -78,8 +78,8 @@
         }
     },
     "peerDependencies": {
-        "@guardian/src-foundations": "^1.1.0",
-        "@guardian/src-icons": "^1.9.1",
+        "@guardian/src-foundations": "^2.4.0",
+        "@guardian/src-icons": "^2.4.0",
         "emotion": "^10.0.27",
         "react": "^16.13.1",
         "react-dom": "^16.13.1"

--- a/src/AudioAtom.tsx
+++ b/src/AudioAtom.tsx
@@ -32,7 +32,7 @@ const figureStyle = css`
 `;
 
 const kickerStyle = (pillar: Pillar) => css`
-    color: ${pillarPalette[pillar].main};
+    color: ${pillarPalette[pillar][400]};
     ${headline.xxxsmall({ fontWeight: 'bold' })};
 `;
 
@@ -105,7 +105,7 @@ const progressBarInputStyle = (pillar: Pillar) => css`
     appearance: none;
     background-image: linear-gradient(
         to right,
-        ${pillarPalette[pillar].main} 0%,
+        ${pillarPalette[pillar][400]} 0%,
         ${palette.neutral[60]} 0%
     );
     height: 6px;
@@ -158,7 +158,7 @@ const PauseButton = ({
         >
             <g fill="none" fillRule="evenodd">
                 <circle
-                    fill={pillarPalette[pillar].main}
+                    fill={pillarPalette[pillar][400]}
                     cx="15"
                     cy="15"
                     r="15"
@@ -188,7 +188,7 @@ const PlayButton = ({
         >
             <g fill="none" fillRule="evenodd">
                 <circle
-                    fill={pillarPalette[pillar].main}
+                    fill={pillarPalette[pillar][400]}
                     cx="15"
                     cy="15"
                     r="15"

--- a/src/YoutubeAtom/YoutubeMeta.tsx
+++ b/src/YoutubeAtom/YoutubeMeta.tsx
@@ -17,8 +17,8 @@ const iconWrapperStyles = (pillar: Pillar) => css`
     height: 23px;
     /* Below we force the colour to be bright if the pillar is news (because it looks better) */
     background-color: ${pillar === Pillar.News
-        ? pillarPalette[pillar].bright
-        : pillarPalette[pillar].main};
+        ? pillarPalette[pillar][500]
+        : pillarPalette[pillar][400]};
     border-radius: 50%;
     display: inline-block;
 
@@ -36,8 +36,8 @@ const iconWrapperStyles = (pillar: Pillar) => css`
 const durationStyles = (pillar: Pillar) => css`
     /* Below we force the colour to be bright if the pillar is news (because it looks better) */
     color: ${pillar === Pillar.News
-        ? pillarPalette[pillar].bright
-        : pillarPalette[pillar].main};
+        ? pillarPalette[pillar][500]
+        : pillarPalette[pillar][400]};
     ${textSans.xsmall({ fontWeight: `bold` })}
 `;
 

--- a/src/lib/pillarPalette.ts
+++ b/src/lib/pillarPalette.ts
@@ -10,11 +10,6 @@ import {
 type colour = string;
 
 interface PillarColours {
-    dark: colour;
-    main: colour;
-    bright: colour;
-    pastel: colour;
-    faded: colour;
     300: colour;
     400: colour;
     500: colour;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1151,15 +1151,15 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
-"@guardian/src-foundations@^1.0.1":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-1.1.0.tgz#1955a3933c3aecfae46d4688a43f331866386b94"
-  integrity sha512-XGZSbHuHf20kewajdIAOPk7jb6mB6+wPYFj+CUuKcEPXXjNLQ4K5WVIzu0xQ9Fa5aO1wG/s0ek0ii9KbpDcbNA==
+"@guardian/src-foundations@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-2.4.0.tgz#e87d935881b5554e35c00a5b054ced948ac1b5c7"
+  integrity sha512-yShUGqULr7joOxWW+sUq9uziXC9WfIv/S05Tmi8QxevYpkgrSyLK0jSUY3S2ZRg+SfXSyX1g30qvOI+NuhSKfA==
 
-"@guardian/src-icons@^1.9.1":
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/@guardian/src-icons/-/src-icons-1.9.1.tgz#86d9dba8085042014e5851db8b2388ff2a25c201"
-  integrity sha512-wdLFDoE8qvKxRyb3EjTBvErMxsYpsckrb/2eRtEjqm4dP2nycK51qTyhLS9aJXvILQnlZLKg5yVbxKdYQokEgQ==
+"@guardian/src-icons@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@guardian/src-icons/-/src-icons-2.4.0.tgz#6560e1e0f486da8aac58b7f9da802bcf93178b89"
+  integrity sha512-un/QwSgtBpcAti3sVOo9vtTWlnWlQ8yGsw75oF2zpzyu542ZMb0AEOZnrmZ7zc/df2M6cFoUIFkQYs/alX+HVA==
 
 "@guardian/types@^0.4.4":
   version "0.4.4"


### PR DESCRIPTION
## What does this change?
Updates the src packages in atoms-rendering. This should fix some problems we had integrating audio atoms into apps-rendering https://github.com/guardian/apps-rendering/pull/781

Updated the `pillarPalette` record to use the new src colours (following the src 2.0 migration guide)