### PR TITLE
fix window undefined caused by SSR on Youtube block element

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -515,5 +515,4 @@
 </style>
 <script>
     document.cookie = 'gu-cmp-disabled=true';
-    isStory = true;
 </script>

--- a/src/YoutubeAtom/YoutubeAtom.tsx
+++ b/src/YoutubeAtom/YoutubeAtom.tsx
@@ -81,6 +81,13 @@ export const YoutubeAtom = ({
 }: YoutubeAtomType): JSX.Element => {
     const embedConfig =
         adTargeting && JSON.stringify(buildEmbedConfig(adTargeting));
+
+    // if window is undefined it is because this logic is running on the server side
+    const origin =
+        typeof window !== 'undefined' && window.isStory
+            ? ''
+            : '&origin=https://www.theguardian.com';
+    const iframeSrc = `https://www.youtube.com/embed/${videoMeta.assetId}?embed_config=${embedConfig}&enablejsapi=1${origin}&widgetid=1&modestbranding=1`;
     return (
         <div>
             <MaintainAspectRatio height={height} width={width}>
@@ -89,13 +96,7 @@ export const YoutubeAtom = ({
                     width={width}
                     height={height}
                     id={videoMeta.assetId}
-                    src={`https://www.youtube.com/embed/${
-                        videoMeta.assetId
-                    }?embed_config=${embedConfig}&enablejsapi=1${
-                        window.isStory
-                            ? ''
-                            : '&origin=https://www.theguardian.com'
-                    }&widgetid=1&modestbranding=1`}
+                    src={iframeSrc}
                     // needed in order to allow `player.playVideo();` to be able to run
                     // https://stackoverflow.com/a/53298579/7378674
                     allow="autoplay"

--- a/src/YoutubeAtom/YoutubeAtom.tsx
+++ b/src/YoutubeAtom/YoutubeAtom.tsx
@@ -84,27 +84,25 @@ export const YoutubeAtom = ({
             : '&origin=https://www.theguardian.com';
     const iframeSrc = `https://www.youtube.com/embed/${videoMeta.assetId}?embed_config=${embedConfig}&enablejsapi=1${origin}&widgetid=1&modestbranding=1`;
     return (
-        <div>
-            <MaintainAspectRatio height={height} width={width}>
-                <iframe
-                    title={title}
-                    width={width}
-                    height={height}
+        <MaintainAspectRatio height={height} width={width}>
+            <iframe
+                title={title}
+                width={width}
+                height={height}
+                id={videoMeta.assetId}
+                src={iframeSrc}
+                // needed in order to allow `player.playVideo();` to be able to run
+                // https://stackoverflow.com/a/53298579/7378674
+                allow="autoplay"
+                tabIndex={overlayImage ? -1 : 0}
+            />
+            {overlayImage && (
+                <YoutubeOverlay
+                    image={overlayImage}
+                    duration={duration}
                     id={videoMeta.assetId}
-                    src={iframeSrc}
-                    // needed in order to allow `player.playVideo();` to be able to run
-                    // https://stackoverflow.com/a/53298579/7378674
-                    allow="autoplay"
-                    tabIndex={overlayImage ? -1 : 0}
                 />
-                {overlayImage && (
-                    <YoutubeOverlay
-                        image={overlayImage}
-                        duration={duration}
-                        id={videoMeta.assetId}
-                    />
-                )}
-            </MaintainAspectRatio>
-        </div>
+            )}
+        </MaintainAspectRatio>
     );
 };

--- a/src/YoutubeAtom/YoutubeAtom.tsx
+++ b/src/YoutubeAtom/YoutubeAtom.tsx
@@ -3,12 +3,6 @@ import React from 'react';
 import { YoutubeOverlay } from './YoutubeOverlay';
 import { MaintainAspectRatio } from './MaintainAspectRatio';
 
-declare global {
-    interface Window {
-        isStory?: boolean;
-    }
-}
-
 type EmbedConfig = {
     adsConfig: {
         adTagParameters: {
@@ -84,7 +78,8 @@ export const YoutubeAtom = ({
 
     // if window is undefined it is because this logic is running on the server side
     const origin =
-        typeof window !== 'undefined' && window.isStory
+        typeof window !== 'undefined' &&
+        window.location.hostname === 'localhost'
             ? ''
             : '&origin=https://www.theguardian.com';
     const iframeSrc = `https://www.youtube.com/embed/${videoMeta.assetId}?embed_config=${embedConfig}&enablejsapi=1${origin}&widgetid=1&modestbranding=1`;

--- a/src/YoutubeAtom/YoutubeOverlay.tsx
+++ b/src/YoutubeAtom/YoutubeOverlay.tsx
@@ -101,6 +101,9 @@ export const YoutubeOverlay = ({
     };
 
     useEffect(() => {
+        // if window is undefined it is because this logic is running on the server side
+        if (typeof window === 'undefined') return;
+
         if (window.YT) {
             loadVideo();
         } else {


### PR DESCRIPTION
## What does this change?
Checks if `window` is defined before using that variable

## Why?
When running this component on DCR, we would get a `window` is undefined. This is because when ServerSideRendering, window does not exist. Therefore we need to make a check that `window` exists before using it.
