### PR TITLE
Acast Audio

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -5,7 +5,7 @@ module.exports = {
     addons: ['@storybook/preset-typescript'],
     webpackFinal: async (config, { configType }) => {
         config.module.rules.push({
-            test: /(\.tsx?|\.js?)$/,
+            test: /(.tsx?$/,
             use: [
                 {
                     loader: 'babel-loader',

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -5,7 +5,7 @@ module.exports = {
     addons: ['@storybook/preset-typescript'],
     webpackFinal: async (config, { configType }) => {
         config.module.rules.push({
-            test: /\.tsx?$/,
+            test: /(\.tsx?|\.js?)$/,
             use: [
                 {
                     loader: 'babel-loader',

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -5,7 +5,7 @@ module.exports = {
     addons: ['@storybook/preset-typescript'],
     webpackFinal: async (config, { configType }) => {
         config.module.rules.push({
-            test: /(.tsx?$/,
+            test: /\.tsx?$/,
             use: [
                 {
                     loader: 'babel-loader',

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
         "husky": "^4.2.5",
         "jest": "^26.5.2",
         "jest-environment-jsdom-sixteen": "^1.0.3",
+        "ts-jest": "^24.3.0",
         "microbundle": "^0.12.0",
         "prettier": "^2.0.5",
         "pretty-quick": "^2.0.1",
@@ -88,9 +89,37 @@
         "react-dom": "^16.13.1"
     },
     "jest": {
+        "preset": "ts-jest/presets/js-with-babel",
         "testEnvironment": "jest-environment-jsdom-sixteen",
+        "moduleFileExtensions": [
+            "ts",
+            "tsx",
+            "js"
+        ],
+        "transform": {
+            "^.+\\.(ts|tsx)$": "ts-jest"
+        },
+        "globals": {
+            "ts-jest": {
+                "diagnostics": false,
+                "tsConfigFile": "tsconfig.json"
+            }
+        },
+        "testMatch": [
+            "**/*.test.+(ts|tsx|js)"
+        ],
+        "moduleNameMapper": {
+            "^svgs/(.*)$": "<rootDir>/__mocks__/svgMock.tsx",
+            "^(.*)\\.svg$": "<rootDir>/__mocks__/svgMock.tsx",
+            "^@root(.*)$": "<rootDir>$1",
+            "^@frontend(.*)$": "<rootDir>/src$1",
+            "^@guardian/src-foundations/(.*)(?<!cjs)$": "@guardian/src-foundations/$1/cjs"
+        },
         "transformIgnorePatterns": [
-            "node_modules/(?!(@guardian/src-foundations|@guardian/types)/)"
+            "/node_modules/(?!@guardian/).+\\.js$"
+        ],
+        "collectCoverageFrom": [
+            "src/**/*.{ts,tsx}"
         ]
     }
 }

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     },
     "peerDependencies": {
         "@guardian/src-foundations": "^2.4.0",
+        "@guardian/consent-management-platform": "^6.6.0",
         "@guardian/src-icons": "^2.4.0",
         "emotion": "^10.0.27",
         "react": "^16.13.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
         "@babel/plugin-transform-runtime": "^7.9.6",
         "@babel/preset-react": "^7.10.4",
         "@babel/preset-typescript": "^7.9.0",
+        "@guardian/consent-management-platform": "^6.6.0",
         "@guardian/src-foundations": "^2.4.0",
         "@guardian/src-icons": "^2.4.0",
         "@guardian/types": "^0.4.4",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
         "@babel/plugin-transform-runtime": "^7.9.6",
         "@babel/preset-react": "^7.10.4",
         "@babel/preset-typescript": "^7.9.0",
-        "@guardian/consent-management-platform": "^6.6.0",
         "@guardian/src-foundations": "^2.4.0",
         "@guardian/src-icons": "^2.4.0",
         "@guardian/types": "^0.4.4",
@@ -52,12 +51,12 @@
         "husky": "^4.2.5",
         "jest": "^26.5.2",
         "jest-environment-jsdom-sixteen": "^1.0.3",
-        "ts-jest": "^24.3.0",
         "microbundle": "^0.12.0",
         "prettier": "^2.0.5",
         "pretty-quick": "^2.0.1",
         "react": "^16.13.1",
-        "react-dom": "^16.13.1"
+        "react-dom": "^16.13.1",
+        "ts-jest": "^24.3.0"
     },
     "eslintConfig": {
         "root": true,
@@ -81,7 +80,6 @@
         }
     },
     "peerDependencies": {
-        "@guardian/consent-management-platform": "^6.6.0",
         "@guardian/src-foundations": "^2.4.0",
         "@guardian/src-icons": "^2.4.0",
         "emotion": "^10.0.27",
@@ -89,37 +87,9 @@
         "react-dom": "^16.13.1"
     },
     "jest": {
-        "preset": "ts-jest/presets/js-with-babel",
         "testEnvironment": "jest-environment-jsdom-sixteen",
-        "moduleFileExtensions": [
-            "ts",
-            "tsx",
-            "js"
-        ],
-        "transform": {
-            "^.+\\.(ts|tsx)$": "ts-jest"
-        },
-        "globals": {
-            "ts-jest": {
-                "diagnostics": false,
-                "tsConfigFile": "tsconfig.json"
-            }
-        },
-        "testMatch": [
-            "**/*.test.+(ts|tsx|js)"
-        ],
-        "moduleNameMapper": {
-            "^svgs/(.*)$": "<rootDir>/__mocks__/svgMock.tsx",
-            "^(.*)\\.svg$": "<rootDir>/__mocks__/svgMock.tsx",
-            "^@root(.*)$": "<rootDir>$1",
-            "^@frontend(.*)$": "<rootDir>/src$1",
-            "^@guardian/src-foundations/(.*)(?<!cjs)$": "@guardian/src-foundations/$1/cjs"
-        },
         "transformIgnorePatterns": [
-            "/node_modules/(?!@guardian/).+\\.js$"
-        ],
-        "collectCoverageFrom": [
-            "src/**/*.{ts,tsx}"
+            "node_modules/(?!(@guardian/src-foundations|@guardian/types)/)"
         ]
     }
 }

--- a/package.json
+++ b/package.json
@@ -79,8 +79,8 @@
         }
     },
     "peerDependencies": {
-        "@guardian/src-foundations": "^2.4.0",
         "@guardian/consent-management-platform": "^6.6.0",
+        "@guardian/src-foundations": "^2.4.0",
         "@guardian/src-icons": "^2.4.0",
         "emotion": "^10.0.27",
         "react": "^16.13.1",

--- a/src/Answers.tsx
+++ b/src/Answers.tsx
@@ -66,13 +66,13 @@ export const UnselectedAnswer = ({
             onKeyPress={onKeyPress}
             tabIndex={disabled ? -1 : 0}
             htmlFor={`answer-${id}`}
-            data-answerType={
+            data-answertype={
                 disabled
                     ? 'unselected-disabled-answer'
                     : 'unselected-enabled-answer'
             }
             id={id}
-            data-testId={id}
+            data-testid={id}
         >
             {answerText}
         </label>
@@ -118,8 +118,8 @@ export const CorrectSelectedAnswer = ({
         <label
             className={correctSelectedAnswerStyles}
             id={id}
-            data-testId={id}
-            data-answerType="correct-selected-answer"
+            data-testid={id}
+            data-answertype="correct-selected-answer"
         >
             <span
                 className={css`
@@ -163,8 +163,8 @@ export const NonSelectedCorrectAnswer = ({
         <label
             className={nonSelectedCorrectAnswerLabelStyles}
             id={id}
-            data-testId={id}
-            data-answerType="non-selected-correct-answer"
+            data-testid={id}
+            data-answertype="non-selected-correct-answer"
         >
             <span
                 className={css`
@@ -212,8 +212,8 @@ export const IncorrectAnswer = ({
         <label
             className={incorrectAnswerLabelStyles}
             id={id}
-            data-testId={id}
-            data-answerType="incorrect-answer"
+            data-testid={id}
+            data-answertype="incorrect-answer"
         >
             {answerText}
         </label>

--- a/src/AudioAtom.tsx
+++ b/src/AudioAtom.tsx
@@ -5,10 +5,6 @@ import { textSans, headline } from '@guardian/src-foundations/typography';
 import { palette } from '@guardian/src-foundations';
 import { Pillar } from '@guardian/types/Format';
 import { focusHalo } from '@guardian/src-foundations/accessibility';
-import {
-    onConsentChange,
-    getConsentFor,
-} from '@guardian/consent-management-platform';
 
 import { pillarPalette } from './lib/pillarPalette';
 import { AudioAtomType } from './types';
@@ -307,16 +303,17 @@ export const AudioAtom = ({
     // *     ACast     *
     // *****************
     useEffect(() => {
-        onConsentChange((state) => {
-            const consentGiven = getConsentFor('acast', state);
-
-            if (acastEnabled && consentGiven && !adFreeUser) {
-                // Replace the default url with an acast enabled on, causing the component to
-                // rerender with a new track url containing adverts
-                setUrlToUse(
-                    trackUrl.replace('https://', 'https://flex.acast.com/'),
-                );
-            }
+        import('@guardian/consent-management-platform').then((cmp) => {
+            cmp.onConsentChange((state: any) => {
+                const consentGiven = cmp.getConsentFor('acast', state);
+                if (acastEnabled && consentGiven && !adFreeUser) {
+                    // Replace the default url with an acast enabled on, causing the component to
+                    // rerender with a new track url containing adverts
+                    setUrlToUse(
+                        trackUrl.replace('https://', 'https://flex.acast.com/'),
+                    );
+                }
+            });
         });
     }, [acastEnabled, adFreeUser]);
 

--- a/src/AudioAtom.tsx
+++ b/src/AudioAtom.tsx
@@ -202,6 +202,12 @@ const PlayButton = ({
     </button>
 );
 
+const buildUrl = (basicUrl: string, shouldUseAcast?: boolean) => {
+    return shouldUseAcast
+        ? basicUrl.replace('https://', 'https://flex.acast.com/')
+        : basicUrl;
+};
+
 export const AudioAtom = ({
     id,
     trackUrl,
@@ -217,7 +223,9 @@ export const AudioAtom = ({
     const [currentTime, setCurrentTime] = useState<number>(0);
     const [percentPlayed, setPercentPlayed] = useState<number>(0);
     // url
-    const [urlToUse, setUrlToUse] = useState<string>(trackUrl);
+    const [urlToUse, setUrlToUse] = useState<string>(
+        buildUrl(trackUrl, shouldUseAcast),
+    );
 
     useEffect(() => {
         const updateCurrentTimeAndPosition = () => {
@@ -302,11 +310,7 @@ export const AudioAtom = ({
 
     // If Acast is enabled, replace the default url with an ad enabled one
     useEffect(() => {
-        setUrlToUse(
-            shouldUseAcast
-                ? trackUrl.replace('https://', 'https://flex.acast.com/')
-                : trackUrl,
-        );
+        setUrlToUse(buildUrl(trackUrl, shouldUseAcast));
     }, [shouldUseAcast]);
 
     return (

--- a/src/AudioAtom.tsx
+++ b/src/AudioAtom.tsx
@@ -382,6 +382,7 @@ export const AudioAtom = ({
                                 step="1"
                                 value={percentPlayed}
                                 onClick={updateAudioCurrentTime}
+                                readOnly={true}
                             />
                         </div>
                         <div className={timeDurationStyle}>

--- a/src/AudioAtom.tsx
+++ b/src/AudioAtom.tsx
@@ -221,14 +221,14 @@ export const AudioAtom = ({
 
     useEffect(() => {
         const updateCurrentTimeAndPosition = () => {
+            const currentTime: number | null =
+                audioEl.current && audioEl.current.currentTime;
+            const duration: number | null =
+                audioEl.current && audioEl.current.duration;
             setPercentPlayed(
-                audioEl.current
-                    ? (audioEl.current.currentTime / audioEl.current.duration) *
-                          100
-                    : 0,
+                currentTime && duration ? (currentTime / duration) * 100 : 0,
             );
-
-            setCurrentTime(audioEl.current ? audioEl.current.currentTime : 0);
+            setCurrentTime(currentTime || 0);
         };
 
         audioEl.current &&
@@ -244,7 +244,7 @@ export const AudioAtom = ({
                       updateCurrentTimeAndPosition,
                   )
                 : undefined;
-    }, [audioEl, setCurrentTime]);
+    }, [audioEl, setCurrentTime, shouldUseAcast]);
 
     // update duration time
     const [durationTime, setDurationTime] = useState<number>(0);

--- a/src/AudioAtom.tsx
+++ b/src/AudioAtom.tsx
@@ -216,6 +216,9 @@ export const AudioAtom = ({
     // update current time and progress bar position
     const [currentTime, setCurrentTime] = useState<number>(0);
     const [percentPlayed, setPercentPlayed] = useState<number>(0);
+    // url
+    const [urlToUse, setUrlToUse] = useState<string>(trackUrl);
+
     useEffect(() => {
         const updateCurrentTimeAndPosition = () => {
             setPercentPlayed(
@@ -298,9 +301,13 @@ export const AudioAtom = ({
     }, [audioEl, progressBarEl]);
 
     // If Acast is enabled, replace the default url with an ad enabled one
-    const urlToUse = shouldUseAcast
-        ? trackUrl.replace('https://', 'https://flex.acast.com/')
-        : trackUrl;
+    useEffect(() => {
+        setUrlToUse(
+            shouldUseAcast
+                ? trackUrl.replace('https://', 'https://flex.acast.com/')
+                : trackUrl,
+        );
+    }, [shouldUseAcast]);
 
     return (
         <figure

--- a/src/AudioAtom.tsx
+++ b/src/AudioAtom.tsx
@@ -208,12 +208,10 @@ export const AudioAtom = ({
     kicker,
     title,
     pillar,
-    acastEnabled,
-    adFreeUser,
+    shouldUseAcast,
 }: AudioAtomType): JSX.Element => {
     const audioEl = useRef<HTMLAudioElement>(null);
     const [isPlaying, setIsPlaying] = useState<boolean>(false);
-    const [urlToUse, setUrlToUse] = useState<string>(trackUrl);
 
     // update current time and progress bar position
     const [currentTime, setCurrentTime] = useState<number>(0);
@@ -299,23 +297,10 @@ export const AudioAtom = ({
         return () => document.removeEventListener('keydown', keyListener);
     }, [audioEl, progressBarEl]);
 
-    // *****************
-    // *     ACast     *
-    // *****************
-    useEffect(() => {
-        import('@guardian/consent-management-platform').then((cmp) => {
-            cmp.onConsentChange((state: any) => {
-                const consentGiven = cmp.getConsentFor('acast', state);
-                if (acastEnabled && consentGiven && !adFreeUser) {
-                    // Replace the default url with an acast enabled on, causing the component to
-                    // rerender with a new track url containing adverts
-                    setUrlToUse(
-                        trackUrl.replace('https://', 'https://flex.acast.com/'),
-                    );
-                }
-            });
-        });
-    }, [acastEnabled, adFreeUser]);
+    // If Acast is enabled, replace the default url with an ad enabled one
+    const urlToUse = shouldUseAcast
+        ? trackUrl.replace('https://', 'https://flex.acast.com/')
+        : trackUrl;
 
     return (
         <figure

--- a/src/QuizAtom.test.tsx
+++ b/src/QuizAtom.test.tsx
@@ -37,7 +37,7 @@ describe('QuizAtom', () => {
             rerender(<QuizAtom id="123abc" questions={questions} />);
 
             expect(
-                getByTestId(correctAnswer.id).getAttribute('data-answerType'),
+                getByTestId(correctAnswer.id).getAttribute('data-answertype'),
             ).toBe('correct-selected-answer');
         });
 
@@ -50,10 +50,10 @@ describe('QuizAtom', () => {
             rerender(<QuizAtom id="123abc" questions={questions} />);
 
             expect(
-                getByTestId(incorrectAnswer.id).getAttribute('data-answerType'),
+                getByTestId(incorrectAnswer.id).getAttribute('data-answertype'),
             ).toBe('incorrect-answer');
             expect(
-                getByTestId(correctAnswer.id).getAttribute('data-answerType'),
+                getByTestId(correctAnswer.id).getAttribute('data-answertype'),
             ).toBe('non-selected-correct-answer');
         });
 
@@ -64,7 +64,7 @@ describe('QuizAtom', () => {
 
             expect(
                 getByTestId(incorrectUnselectedAnswer.id).getAttribute(
-                    'data-answerType',
+                    'data-answertype',
                 ),
             ).toBe('unselected-enabled-answer');
 
@@ -73,7 +73,7 @@ describe('QuizAtom', () => {
 
             expect(
                 getByTestId(incorrectUnselectedAnswer.id).getAttribute(
-                    'data-answerType',
+                    'data-answertype',
                 ),
             ).toBe('unselected-disabled-answer');
         });

--- a/src/QuizAtom.tsx
+++ b/src/QuizAtom.tsx
@@ -99,7 +99,7 @@ export const Question = ({
                         position: relative;
                     `}
                 >
-                    {answers.map((answer, index) => {
+                    {answers.map((answer) => {
                         const isAnswered = selected !== undefined;
                         const isSelected = selected === answer.id;
 
@@ -108,6 +108,7 @@ export const Question = ({
                                 if (answer.isCorrect) {
                                     return (
                                         <CorrectSelectedAnswer
+                                            key={answer.id}
                                             id={answer.id}
                                             answerText={answer.text}
                                             explainerText={
@@ -120,6 +121,7 @@ export const Question = ({
                                 if (!answer.isCorrect) {
                                     return (
                                         <IncorrectAnswer
+                                            key={answer.id}
                                             id={answer.id}
                                             answerText={answer.text}
                                         />
@@ -130,6 +132,7 @@ export const Question = ({
                             if (answer.isCorrect) {
                                 return (
                                     <NonSelectedCorrectAnswer
+                                        key={answer.id}
                                         id={answer.id}
                                         answerText={answer.text}
                                         explainerText={answer.revealText || ''}
@@ -139,6 +142,7 @@ export const Question = ({
 
                             return (
                                 <UnselectedAnswer
+                                    key={answer.id}
                                     id={answer.id}
                                     disabled={true}
                                     answerText={answer.text}
@@ -148,6 +152,7 @@ export const Question = ({
 
                         return (
                             <UnselectedAnswer
+                                key={answer.id}
                                 id={answer.id}
                                 disabled={false}
                                 answerText={answer.text}

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,8 @@ export type AudioAtomType = {
     kicker: string;
     title?: string;
     pillar: Pillar;
+    acastEnabled?: boolean;
+    adFreeUser?: boolean;
 };
 
 export type ChartAtomType = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,8 +12,7 @@ export type AudioAtomType = {
     kicker: string;
     title?: string;
     pillar: Pillar;
-    acastEnabled?: boolean;
-    adFreeUser?: boolean;
+    shouldUseAcast?: boolean;
 };
 
 export type ChartAtomType = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1151,11 +1151,6 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
-"@guardian/consent-management-platform@^6.6.0":
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.6.0.tgz#e6328fdfba40bb423f8a63084b1096423041a564"
-  integrity sha512-QIEd65+sPN56VMekx5JinZZIFHq0ahfG1HGISfG9HRG6+31r1VNv8d6VXySszJXhY1ksCh4Rtn0BW3MmSq5NkQ==
-
 "@guardian/src-foundations@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-2.4.0.tgz#e87d935881b5554e35c00a5b054ced948ac1b5c7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3794,6 +3794,13 @@ browserslist@^4.0.0, browserslist@^4.12.0, browserslist@^4.8.5:
     node-releases "^1.1.53"
     pkg-up "^2.0.0"
 
+bs-logger@0.x:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
+  integrity sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==
+  dependencies:
+    fast-json-stable-stringify "2.x"
+
 bser@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.1.1.tgz#e6787da20ece9d07998533cfd9de6f5c38f4bc05"
@@ -3801,7 +3808,7 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
-buffer-from@^1.0.0:
+buffer-from@1.x, buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
@@ -3940,6 +3947,11 @@ camelcase-keys@^6.2.2:
     camelcase "^5.3.1"
     map-obj "^4.0.0"
     quick-lru "^4.0.1"
+
+camelcase@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
+  integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
 
 camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
@@ -5905,7 +5917,7 @@ fast-glob@^3.1.1:
     micromatch "^4.0.2"
     picomatch "^2.2.1"
 
-fast-json-stable-stringify@^2.0.0:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -7165,6 +7177,13 @@ is-color-stop@^1.0.0:
     hsla-regex "^1.0.0"
     rgb-regex "^1.0.1"
     rgba-regex "^1.0.0"
+
+is-core-module@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.0.0.tgz#58531b70aed1db7c0e8d4eb1a0a2d1ddd64bd12d"
+  integrity sha512-jq1AH6C8MuteOoBPwkxHafmByhL9j5q4OaPGdbuD+ZtQJVzH+i6E3BJDQcBA09k57i2Hh2yQbEG8yObZ0jdlWw==
+  dependencies:
+    has "^1.0.3"
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -8444,19 +8463,19 @@ json3@^3.3.2:
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.3.tgz#7fc10e375fc5ae42c4705a5cc0aa6f62be305b81"
   integrity sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==
 
+json5@2.x, json5@^2.1.1, json5@^2.1.2:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
+  integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
+  dependencies:
+    minimist "^1.2.5"
+
 json5@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
   integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
   dependencies:
     minimist "^1.2.0"
-
-json5@^2.1.1, json5@^2.1.2:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
-  integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
-  dependencies:
-    minimist "^1.2.5"
 
 jsonfile@^2.1.0:
   version "2.4.0"
@@ -8715,7 +8734,7 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
-lodash.memoize@^4.1.2:
+lodash.memoize@4.x, lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
@@ -8837,6 +8856,11 @@ make-dir@^3.0.0, make-dir@^3.0.2:
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
   dependencies:
     semver "^6.0.0"
+
+make-error@1.x:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
 makeerror@1.0.x:
   version "1.0.11"
@@ -9216,7 +9240,7 @@ mixin-object@^2.0.1:
     for-in "^0.1.3"
     is-extendable "^0.1.1"
 
-mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@~0.5.1:
+mkdirp@0.x, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -11314,6 +11338,14 @@ resolve@1.12.0:
   dependencies:
     path-parse "^1.0.6"
 
+resolve@1.x:
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.18.1.tgz#018fcb2c5b207d2a6424aee361c5a266da8f4130"
+  integrity sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==
+  dependencies:
+    is-core-module "^2.0.0"
+    path-parse "^1.0.6"
+
 resolve@^1.1.6, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.15.1, resolve@^1.16.0, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.8.1:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
@@ -11628,7 +11660,7 @@ semver-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-2.0.0.tgz#a93c2c5844539a770233379107b38c7b4ac9d338"
   integrity sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==
 
-"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -12675,6 +12707,22 @@ ts-dedent@^1.1.0, ts-dedent@^1.1.1:
   resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-1.1.1.tgz#68fad040d7dbd53a90f545b450702340e17d18f3"
   integrity sha512-UGTRZu1evMw4uTPyYF66/KFd22XiU+jMaIuHrkIHQ2GivAXVlLV0v/vHrpOuTRf9BmpNHi/SO7Vd0rLu0y57jg==
 
+ts-jest@^24.3.0:
+  version "24.3.0"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-24.3.0.tgz#b97814e3eab359ea840a1ac112deae68aa440869"
+  integrity sha512-Hb94C/+QRIgjVZlJyiWwouYUF+siNJHJHknyspaOcZ+OQAIdFG/UrdQVXw/0B8Z3No34xkUXZJpOTy9alOWdVQ==
+  dependencies:
+    bs-logger "0.x"
+    buffer-from "1.x"
+    fast-json-stable-stringify "2.x"
+    json5 "2.x"
+    lodash.memoize "4.x"
+    make-error "1.x"
+    mkdirp "0.x"
+    resolve "1.x"
+    semver "^5.5"
+    yargs-parser "10.x"
+
 ts-pnp@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
@@ -13411,6 +13459,13 @@ yaml@^1.7.2:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
   integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==
+
+yargs-parser@10.x:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
+  integrity sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==
+  dependencies:
+    camelcase "^4.1.0"
 
 yargs-parser@^13.1.2:
   version "13.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1151,6 +1151,11 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
+"@guardian/consent-management-platform@^6.6.0":
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.6.0.tgz#e6328fdfba40bb423f8a63084b1096423041a564"
+  integrity sha512-QIEd65+sPN56VMekx5JinZZIFHq0ahfG1HGISfG9HRG6+31r1VNv8d6VXySszJXhY1ksCh4Rtn0BW3MmSq5NkQ==
+
 "@guardian/src-foundations@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-2.4.0.tgz#e87d935881b5554e35c00a5b054ced948ac1b5c7"


### PR DESCRIPTION
## What does this change?
We should only serve audio with ads in it if the user has consented to this. This PR adds a check to see if the user has consented and, if they have, it reloads the AudioAtom using a new url, one which points to the Acast service to get ad enabled content.

Note. In the gifs below the 14m track is the one without ads, and the 17m track includes adverts.

### Before
![2020-11-04 11 29 33](https://user-images.githubusercontent.com/1336821/98106279-1f59c480-1e91-11eb-8feb-47f0944c6ac4.gif)


### After
![2020-11-04 10 06 17](https://user-images.githubusercontent.com/1336821/98105879-7a3eec00-1e90-11eb-823a-2897b0122623.gif)


## What Next?
Once this PR is merged, we need to

1. Release a new version of `@guardian/atoms-rendering`
2. Add the switch `acastEnabled` to DCR
3. Upgrade the version of `atoms-rendering` used in DCR and add the prop, `shouldUseAcast`, using CMP to check if the user has given consent or not
