### PR TITLE
Use Both Node 12 And Node 10 In CI

### DIFF
--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -4,10 +4,14 @@ on: [push]
 jobs:
     run:
         runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                node-version: [10.x, 12.x]
         steps:
             - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v1
               with:
-                  node-version: '10.x'
+                  node-version: ${{ matrix.node-version }}
             - run: yarn
             - run: CI=true yarn test:ci

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,10 +4,14 @@ on: [push]
 jobs:
     run:
         runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                node-version: [10.x, 12.x]
         steps:
             - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v1
               with:
-                  node-version: '10.x'
+                  node-version: ${{ matrix.node-version }}
             - run: yarn
             - run: yarn lint

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -4,10 +4,14 @@ on: [push]
 jobs:
     run:
         runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                node-version: [10.x, 12.x]
         steps:
             - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v1
               with:
-                  node-version: '10.x'
+                  node-version: ${{ matrix.node-version }}
             - run: yarn
             - run: yarn tsc


### PR DESCRIPTION
## Why?

Atoms-rendering is used by DCR (Node 10) and AR (Node 12), so it would be good to make sure it runs on both. These changes borrow heavily from [image-rendering](https://github.com/guardian/image-rendering/blob/cc9b89b96462a8df78d17bae69787597caaa6363/.github/workflows/node.js.yml).

**Note**: The lint warnings are present in `main`.

## Changes

- Added a "matrix" to use both Node 10 and 12 for the "lint", "tsc" and "test" jobs
