### PR TITLE
Don't snapshot the Tube interactive

### DIFF
--- a/src/InteractiveAtom.stories.tsx
+++ b/src/InteractiveAtom.stories.tsx
@@ -22,3 +22,7 @@ export const DefaultStory = (): JSX.Element => {
         </div>
     );
 };
+DefaultStory.parameters = {
+    // This interactive uses animation which is causing false negatives for Chromatic
+    chromatic: { disable: true },
+};

--- a/src/InteractiveAtom.tsx
+++ b/src/InteractiveAtom.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { unifyPageContent } from './lib/unifyPageContent';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { InteractiveAtomType } from './types';
 
 const figureStyles = css`


### PR DESCRIPTION
Prevents Chromatic taking snapshots of this component.

### Why?
Because this custom animation is triggering false positives on every build, which is annoying.