### PR TITLE
Automate the release

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,4 @@
+template: |
+    ## What’s Changed
+
+    $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,16 @@
+name: Release Drafter
+
+on:
+    push:
+        # branches to consider in the event; optional, defaults to all
+        branches:
+            - main
+
+jobs:
+    update_release_draft:
+        runs-on: ubuntu-latest
+        steps:
+            # Drafts your next Release notes as Pull Requests are merged into "master"
+            - uses: release-drafter/release-drafter@v5
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
     update_release_draft:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-18.04
         steps:
             # Drafts your next Release notes as Pull Requests are merged into "master"
             - uses: release-drafter/release-drafter@v5

--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ Pre-requisits:
 
 1. Ensure your changes are on main
 2. Ensure you have an [npm account](https://docs.npmjs.com/creating-and-publishing-scoped-public-packages) that is authorised for the npm @guardian organisation
-3. `yarn build`
 
 Then:
 

--- a/README.md
+++ b/README.md
@@ -104,14 +104,16 @@ Adding a new atom in `atoms-rendering` involves
 
 An example PR for adding the Profile Atom can be found [here](https://github.com/guardian/atoms-rendering/pull/35/files). The component is defined in [/src/ProfileAtom.tsx](https://github.com/guardian/atoms-rendering/blob/main/src/ProfileAtom.tsx), with the supporting type ProfileAtomType in [src/types.tsx](https://github.com/guardian/atoms-rendering/blob/main/src/types.ts). Types are transpiled when this project is built, and are made available to your rendering project when you include the published library as a dependency.
 
-## Publishing to NPM
+## Releasing a new version / Publishing to NPM
 
-Manual publishing steps:
+Pre-requisits:
 
 1. Ensure your changes are on main
 2. Ensure you have an [npm account](https://docs.npmjs.com/creating-and-publishing-scoped-public-packages) that is authorised for the npm @guardian organisation
 3. `yarn build`
-4. Create a branch, `yourname/v1.0.1`
-5. `yarn publish` (enter new version number, eg. 1.0.1)
-6. Create a PR for the version
-7. Then, in the consuming project, update the version of `@guardian/atoms-rendering` installed to see the changes
+
+Then:
+
+`yarn release --patch` or `yarn release --minor` or `yarn release --major`
+
+Once complete, you can update the version of `@guardian/atoms-rendering` in any consuming project to see the changes

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An Atom is a self contained piece of content that can be inserted into multiple 
 
 ## Usage
 
-### import 
+### import
 
 To import an atom in your project use `yarn add @guardian/atoms-rendering` then
 
@@ -20,7 +20,7 @@ import { TheAtomYouWant } from '@guardian/atoms-rendering';
 
 ### Naming conventions
 
-There is mostly a one to one correspondance between atoms as named by CAPI/frontend and their names in atoms-rendering, with the notable exception that the Media atom is named YoutubeAtom here. 
+There is mostly a one to one correspondance between atoms as named by CAPI/frontend and their names in atoms-rendering, with the notable exception that the Media atom is named YoutubeAtom here.
 
 ## Moving to main
 
@@ -72,11 +72,11 @@ The available yarn commands are given below:
 
 If you want to test a change before publishing to NPM, you will need to point to this repository. For instance, you might want to check in dotcom-rendering on local that a change you make in this library is correct. For this do the following
 
-- In atoms-rendering run `yarn build`,
-- In atoms-rendering run `yarn link`, then
-- In dotcom-rendering run `yarn link "@guardian/atoms-rendering"`. 
+-   In atoms-rendering run `yarn build`,
+-   In atoms-rendering run `yarn link`, then
+-   In dotcom-rendering run `yarn link "@guardian/atoms-rendering"`.
 
-Then you will notice that your 
+Then you will notice that your
 
 ```
 dotcom-rendering/node_modules/@guardian/atoms-rendering
@@ -86,14 +86,14 @@ is a symlink to the atoms-rendering repository.
 
 When you are done, you should
 
-- In dotcom-rendering run `yarn unlink "@guardian/atoms-rendering"`. 
-- In atoms-rendering run `yarn unlink`
+-   In dotcom-rendering run `yarn unlink "@guardian/atoms-rendering"`.
+-   In atoms-rendering run `yarn unlink`
 
-And in dotcom-rendering you might also want to run 
+And in dotcom-rendering you might also want to run
 
-- `yarn install --force`, to get the regular package re-installed. 
+-   `yarn install --force`, to get the regular package re-installed.
 
-## Adding a new atom 
+## Adding a new atom
 
 Adding a new atom in `atoms-rendering` involves
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
     "name": "@guardian/atoms-rendering",
+    "repository": {
+        "type": "ssh",
+        "url": "https://github.com/guardian/atoms-rendering"
+    },
     "version": "2.0.9",
     "source": "src/index.ts",
     "main": "dist/index.js",
@@ -20,7 +24,12 @@
         "lint": "eslint . --ext .ts",
         "test": "jest --watch",
         "test:ci": "jest",
-        "chromatic": "chromatic"
+        "validate": "yarn tsc && yarn test:ci && yarn lint",
+        "chromatic": "chromatic",
+        "release": "yarn version",
+        "preversion": "yarn validate",
+        "postversion": "HUSKY_SKIP_HOOKS=1 git push --tags && HUSKY_SKIP_HOOKS=1 git push && npm publish && echo \"Successfully released version $npm_package_version!\" && echo \"$npm_package_repository_url/releases\" && yarn open-releases",
+        "open-releases": "open \"$(node -e 'console.log(`${require(\"./package.json\").repository.url}/releases`)')\""
     },
     "devDependencies": {
         "@babel/core": "^7.12.3",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "test:ci": "jest",
         "validate": "yarn tsc && yarn test:ci && yarn lint",
         "chromatic": "chromatic",
-        "release": "yarn version",
+        "release": "yarn build && yarn version",
         "preversion": "yarn validate",
         "postversion": "HUSKY_SKIP_HOOKS=1 git push --tags && HUSKY_SKIP_HOOKS=1 git push && npm publish && echo \"Successfully released version $npm_package_version!\" && echo \"$npm_package_repository_url/releases\" && yarn open-releases",
         "open-releases": "open \"$(node -e 'console.log(`${require(\"./package.json\").repository.url}/releases`)')\""


### PR DESCRIPTION
## What?
This PR attempts to improve how we release code. It does this in two ways:

1. By adding the Github Action [Release Drafter](https://github.com/marketplace/actions/release-drafter) to aid in creating useful release documentation

![Screenshot 2020-11-12 at 11 51 54](https://user-images.githubusercontent.com/1336821/98936869-80ab1480-24dd-11eb-94f8-c35887a0a8d1.jpg)


2. By adding a `yarn release` script in `package.json` to automate the following steps:

- Building the package
- Bumping package version
- Adding a git tag
- Pushing the tag to `main`
- Publishing to Npm
- Launching a browser on the [releases page](https://github.com/oliverlloyd/publish-sandbox/releases) for the repo

## Usage
The `release` script just runs `yarn version` under the hood and then that uses the `preversion` and `postversion` hooks to create a workflow

Eg.:
`yarn release` - Set version interactively
or
`yarn release -- patch` - 0.0.1
`yarn release -- minor` - 0.1.0
`yarn release -- major` - 1.0.0

Etc. [See docs](https://classic.yarnpkg.com/en/docs/cli/version/)

### Why are we using `HUSKY_SKIP_HOOKS` twice?
`HUSKY_SKIP_HOOKS` tells husky not to run when we push the tags. We have to set this env for _each_  push because (I presume) husky removes it after it sees it.

### Why skip hooks at all?
We skip hooks in the `release` step because we have already run `validate` in the `preversion` stage. Having a separate `validate` command is both more semantic and also lets use have different levels of validation for Husky and for when we publish because we might, say, want more checks for publishing a version than we do for a simple push to the repo.
