### PR TITLE
Linting ❤️ 

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,12 @@
             "plugin:prettier/recommended",
             "plugin:react/recommended",
             "plugin:@typescript-eslint/recommended"
-        ]
+        ],
+        "rules": {
+            "no-unused-vars": "off",
+            "@typescript-eslint/no-unused-vars": "off",
+            "@typescript-eslint/no-unused-vars-experimental": "error"
+        }
     },
     "husky": {
         "hooks": {

--- a/src/InteractiveAtom.tsx
+++ b/src/InteractiveAtom.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { unifyPageContent } from './lib/unifyPageContent';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { InteractiveAtomType } from './types';
 
 const figureStyles = css`

--- a/src/lib/formatTime.ts
+++ b/src/lib/formatTime.ts
@@ -1,7 +1,7 @@
 const enforceTwoDigitString = (number: number) =>
     number >= 10 ? number : `0${number}`;
 
-export const formatTime = (videoDurationInSeconds: number) => {
+export const formatTime = (videoDurationInSeconds: number): string => {
     const hours = Math.floor(videoDurationInSeconds / 3600);
     const minutes = Math.floor((videoDurationInSeconds % 3600) / 60);
     const seconds = videoDurationInSeconds % 60;


### PR DESCRIPTION
No more lint warning

Fixes a problem where eslint was warning about unused types that were in fact being used.

See: https://stackoverflow.com/questions/57802057/eslint-configuring-no-unused-vars-for-typescript

And also adds a missing return type for a function