### PR TITLE
Export video type

### DIFF
--- a/src/VideoAtom.tsx
+++ b/src/VideoAtom.tsx
@@ -1,18 +1,7 @@
 import React from 'react';
 
+import { VideoAtomType } from './types';
 import { MaintainAspectRatio } from './common/MaintainAspectRatio';
-
-type AssetType = {
-    url: string;
-    mimeType: string;
-};
-
-type VideoAtomType = {
-    assets: AssetType[];
-    poster?: string;
-    height?: number;
-    width?: number;
-};
 
 export const VideoAtom = ({
     assets,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { ProfileAtom } from './ProfileAtom';
 import { QandaAtom } from './QandaAtom';
 import { QuizAtom } from './QuizAtom';
 import { TimelineAtom } from './TimelineAtom';
+import { VideoAtom } from './VideoAtom';
 
 export {
     ExplainerAtom,
@@ -20,4 +21,5 @@ export {
     QandaAtom,
     QuizAtom,
     TimelineAtom,
+    VideoAtom,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,3 +102,14 @@ export interface TimelineEvent {
     body?: string;
     toDate?: string;
 }
+type AssetType = {
+    url: string;
+    mimeType: string;
+};
+
+export interface VideoAtomType {
+    assets: AssetType[];
+    poster?: string;
+    height?: number;
+    width?: number;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,12 +102,13 @@ export interface TimelineEvent {
     body?: string;
     toDate?: string;
 }
+
 type AssetType = {
     url: string;
     mimeType: string;
 };
 
-export interface VideoAtomType {
+export type VideoAtomType = {
     assets: AssetType[];
     poster?: string;
     height?: number;


### PR DESCRIPTION
I missed added the correct exports for the `VideoAtom` on [my last PR](https://github.com/guardian/atoms-rendering/pull/109), adding them here.