### PR TITLE
Use preact render instead of render-to-string from react

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "type": "ssh",
         "url": "https://github.com/guardian/atoms-rendering"
     },
-    "version": "3.0.0-0",
+    "version": "2.4.1",
     "source": "src/index.ts",
     "main": "dist/index.js",
     "module": "dist/index.modern.js",
@@ -101,10 +101,10 @@
         "@guardian/src-foundations": "^2.6.0",
         "@guardian/src-icons": "^2.5.0",
         "emotion": "^10.0.27",
-        "preact": "^10.5.7",
         "preact-render-to-string": "^5.1.12",
         "react": "^16.14.0",
-        "react-dom": "^16.14.0"
+        "react-dom": "^16.14.0",
+        "preact": "^10.5.7"
     },
     "jest": {
         "testEnvironment": "jest-environment-jsdom-sixteen",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
         "jest": "^26.6.3",
         "jest-environment-jsdom-sixteen": "^1.0.3",
         "microbundle": "^0.12.0",
+        "preact-render-to-string": "^5.1.12",
         "prettier": "^2.1.2",
         "pretty-quick": "^3.1.0",
         "react": "^16.14.0",
@@ -99,6 +100,7 @@
         "@guardian/src-foundations": "^2.6.0",
         "@guardian/src-icons": "^2.5.0",
         "emotion": "^10.0.27",
+        "preact-render-to-string": "^5.1.12",
         "react": "^16.14.0",
         "react-dom": "^16.14.0"
     },

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
         "jest": "^26.6.3",
         "jest-environment-jsdom-sixteen": "^1.0.3",
         "microbundle": "^0.12.0",
+        "preact": "^10.5.7",
         "preact-render-to-string": "^5.1.12",
         "prettier": "^2.1.2",
         "pretty-quick": "^3.1.0",
@@ -102,7 +103,8 @@
         "emotion": "^10.0.27",
         "preact-render-to-string": "^5.1.12",
         "react": "^16.14.0",
-        "react-dom": "^16.14.0"
+        "react-dom": "^16.14.0",
+        "preact": "^10.5.7"
     },
     "jest": {
         "testEnvironment": "jest-environment-jsdom-sixteen",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "type": "ssh",
         "url": "https://github.com/guardian/atoms-rendering"
     },
-    "version": "2.4.1",
+    "version": "3.0.0-0",
     "source": "src/index.ts",
     "main": "dist/index.js",
     "module": "dist/index.modern.js",
@@ -101,10 +101,10 @@
         "@guardian/src-foundations": "^2.6.0",
         "@guardian/src-icons": "^2.5.0",
         "emotion": "^10.0.27",
+        "preact": "^10.5.7",
         "preact-render-to-string": "^5.1.12",
         "react": "^16.14.0",
-        "react-dom": "^16.14.0",
-        "preact": "^10.5.7"
+        "react-dom": "^16.14.0"
     },
     "jest": {
         "testEnvironment": "jest-environment-jsdom-sixteen",

--- a/src/lib/unifyPageContent.tsx
+++ b/src/lib/unifyPageContent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderToString } from 'react-dom/server';
+import render from 'preact-render-to-string';
 
 export const unifyPageContent = ({
     css,
@@ -10,7 +10,7 @@ export const unifyPageContent = ({
     js: string;
     html?: string;
 }) =>
-    renderToString(
+    render(
         <html>
             <head>
                 <meta charSet="utf-8" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -11347,6 +11347,11 @@ preact-render-to-string@^5.1.12:
   dependencies:
     pretty-format "^3.8.0"
 
+preact@^10.5.7:
+  version "10.5.7"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.7.tgz#f1d84725539e18f7ccbea937cf3db5895661dbd3"
+  integrity sha512-4oEpz75t/0UNcwmcsjk+BIcDdk68oao+7kxcpc1hQPNs2Oo3ZL9xFz8UBf350mxk/VEdD41L5b4l2dE3Ug3RYg==
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11340,6 +11340,13 @@ postcss@^7.0.32:
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
+preact-render-to-string@^5.1.12:
+  version "5.1.12"
+  resolved "https://registry.yarnpkg.com/preact-render-to-string/-/preact-render-to-string-5.1.12.tgz#3d258a177ef8947f768dd0f2c56629e7fda2dc39"
+  integrity sha512-nXVCOpvepSk9AfPwqS08rf9NDOCs8eeYYlG+7tE85iP5jVyjz+aYb1BYaP5SPdfVWVrzI9L5NzxozUvKaD96tA==
+  dependencies:
+    pretty-format "^3.8.0"
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -11396,6 +11403,11 @@ pretty-format@^26.0.0, pretty-format@^26.6.2:
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
+
+pretty-format@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-3.8.0.tgz#bfbed56d5e9a776645f4b1ff7aa1a3ac4fa3c385"
+  integrity sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U=
 
 pretty-hrtime@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
I was struggling with an error in Dotcom Rendering when trying to upgrade to Webpack 5:

```
  ERROR in ./node_modules/@guardian/atoms-rendering/dist/index.modern.js 1:771-821
  Module not found: Error: Package path ./compat/server is not exported from package /Users/gareth_trufitt/code/dotcom-rendering/node_modules/preact (see exports field in /Users/gareth_trufitt/code/dotcom-rendering/node_modules/preact/package.json)
```

The error came from the use of `import { renderToString } from 'react-dom/server';` in atoms-rendering, but I couldn't for the life of me get Dotcom Rendering to compile it properly, despite the use of it in DCR. I upgraded babel, webpack, preact, preact-render-to-string in both projects, messed around with webpack alias, ensured we were bundling etc but it just wouldn't work.

While this should be functionally identical, the problem will come if anyone uses atoms-rendering in a React project then they'll have to install preact *but* react-dom is [much (much) bigger](https://bundlephobia.com/result?p=react-dom@17.0.1) than [preact](https://bundlephobia.com/result?p=preact@10.5.7) and [preact-render-to-string](https://bundlephobia.com/result?p=preact-render-to-string@5.1.12) - so I am not particularly concerned...