### PR TITLE
Handle youtube race condition

### DIFF
--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -296,7 +296,12 @@ export const YoutubeAtom = ({
         if (typeof window === 'undefined') return;
 
         if (window.YT) {
-            loadVideo();
+            // An undocumented ready callback to handle edge cases were window.YT.Player may not be ready for init
+            // https://stackoverflow.com/a/62254596
+            // @ts-ignore
+            window.YT.ready(() => {
+                loadVideo();
+            });
         } else {
             // If not, load the script asynchronously
             loadScript('https://www.youtube.com/iframe_api').then(() => {

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -295,19 +295,13 @@ export const YoutubeAtom = ({
         // if window is undefined it is because this logic is running on the server side
         if (typeof window === 'undefined') return;
 
-        if (window.YT) {
-            // An undocumented ready callback to handle edge cases were window.YT.Player may not be ready for init
-            // https://stackoverflow.com/a/62254596
-            // @ts-ignore
-            window.YT.ready(() => {
-                loadVideo();
-            });
+        window.onYouTubeIframeAPIReady = loadVideo;
+
+        if (window.YT && window.YT.Player) {
+            loadVideo();
         } else {
             // If not, load the script asynchronously
-            loadScript('https://www.youtube.com/iframe_api').then(() => {
-                // onYouTubeIframeAPIReady will load the video after the script is loaded
-                window.onYouTubeIframeAPIReady = loadVideo;
-            });
+            loadScript('https://www.youtube.com/iframe_api');
         }
     }, []);
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Check `window.YT.Player` is defined and set `onYouTubeIframeAPIReady` early on, not in callback

## How to test
Run on storybook, make sure to refresh the page to check if it doen't load from cache.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
Solution has not been tested directly on DCR due to `yarn link` hooks issue
