### PR TITLE
Use youtube-player to simplify Atom

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
         "@babel/plugin-transform-runtime": "^7.12.1",
         "@babel/preset-react": "^7.10.4",
         "@babel/preset-typescript": "^7.12.1",
-        "@guardian/libs": "^1.4.2",
         "@guardian/src-foundations": "^2.6.0",
         "@guardian/src-icons": "^2.5.0",
         "@guardian/types": "^0.5.2",
@@ -72,7 +71,8 @@
         "pretty-quick": "^3.1.0",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
-        "ts-jest": "^24.3.0"
+        "ts-jest": "^24.3.0",
+        "youtube-player": "^5.5.2"
     },
     "eslintConfig": {
         "root": true,
@@ -101,14 +101,14 @@
         }
     },
     "peerDependencies": {
-        "@guardian/libs": "^1.4.2",
         "@guardian/src-foundations": "^2.6.0",
         "@guardian/src-icons": "^2.5.0",
         "emotion": "^10.0.27",
         "preact": "^10.5.7",
         "preact-render-to-string": "^5.1.12",
         "react": "^16.14.0",
-        "react-dom": "^16.14.0"
+        "react-dom": "^16.14.0",
+        "youtube-player": "^5.5.2"
     },
     "jest": {
         "testEnvironment": "jest-environment-jsdom-sixteen",

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -11,6 +11,18 @@ import { YoutubeStateChangeEventType } from './types';
 import { MaintainAspectRatio } from './common/MaintainAspectRatio';
 import { formatTime } from './lib/formatTime';
 
+type Props = {
+    videoMeta: YoutubeMeta;
+    overlayImage?: { src: string; alt: string };
+    posterImage?: { srcSet: { url: string; width: number }[]; alt: string };
+    adTargeting?: AdTargeting;
+    height?: number;
+    width?: number;
+    title?: string;
+    duration?: number; // in seconds
+    origin?: string;
+    eventEmitters: ((event: VideoEventKey) => void)[];
+};
 declare global {
     interface Window {
         onYouTubeIframeAPIReady: unknown;
@@ -68,19 +80,6 @@ type YoutubeMeta = {
 };
 
 type VideoEventKey = 'play' | '25' | '50' | '75' | 'end' | 'skip';
-
-type YoutubeAtomType = {
-    videoMeta: YoutubeMeta;
-    overlayImage?: { src: string; alt: string };
-    posterImage?: { srcSet: { url: string; width: number }[]; alt: string };
-    adTargeting?: AdTargeting;
-    height?: number;
-    width?: number;
-    title?: string;
-    duration?: number; // in seconds
-    origin?: string;
-    eventEmitters: ((event: VideoEventKey) => void)[];
-};
 
 // https://developers.google.com/youtube/iframe_api_reference#Events
 export const youtubePlayerState = {
@@ -257,7 +256,7 @@ export const YoutubeAtom = ({
     duration,
     origin,
     eventEmitters,
-}: YoutubeAtomType): JSX.Element => {
+}: Props): JSX.Element => {
     const embedConfig =
         adTargeting && JSON.stringify(buildEmbedConfig(adTargeting));
     const originString = origin ? `&origin=${origin}` : '';

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'youtube-player';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
         "isolatedModules": false,
         "noEmit": true
     },
-    "files": ["src/types.ts"],
+    "files": ["src/types.ts", "src/index.d.ts"],
     "include": ["src/"],
     "exclude": ["fixtures", "**/*.test.tsx", "**/*.stories.tsx"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1916,11 +1916,6 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@guardian/libs@^1.4.2":
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-1.4.2.tgz#76f525cf37b37ad58d17288c85008e4ab176a929"
-  integrity sha512-ZACBS1NmAjss8Q60c3SWHZ7alsS2tvjI5rQipEidW3fvWI8kdWWXck6FSM4F42vNzLdRFjAGmzEA36rG/NsZSg==
-
 "@guardian/src-foundations@^2.6.0":
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-2.6.0.tgz#f81466321a125994444167eaa3928dbbbfca7a2e"
@@ -5860,7 +5855,7 @@ date-format@0.0.2:
   resolved "https://registry.yarnpkg.com/date-format/-/date-format-0.0.2.tgz#fafd448f72115ef1e2b739155ae92f2be6c28dd1"
   integrity sha1-+v1Ej3IRXvHitzkVWukvK+bCjdE=
 
-debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0:
+debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -9450,6 +9445,11 @@ listr@0.14.3:
     p-map "^2.0.0"
     rxjs "^6.3.3"
 
+load-script@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/load-script/-/load-script-1.0.0.tgz#0491939e0bee5643ee494a7e3da3d2bac70c6ca4"
+  integrity sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ=
+
 loader-runner@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
@@ -12776,6 +12776,11 @@ simple-swizzle@^0.2.2:
   dependencies:
     is-arrayish "^0.3.1"
 
+sister@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/sister/-/sister-3.0.2.tgz#bb3e39f07b1f75bbe1945f29a27ff1e5a2f26be4"
+  integrity sha512-p19rtTs+NksBRKW9qn0UhZ8/TUI9BPw9lmtHny+Y3TinWlOa9jWh9xB0AtPSdmOy49NJJJSSe0Ey4C7h0TrcYA==
+
 sisteransi@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
@@ -14533,6 +14538,15 @@ yarn-or-npm@^3.0.1:
   dependencies:
     cross-spawn "^6.0.5"
     pkg-dir "^4.2.0"
+
+youtube-player@^5.5.2:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/youtube-player/-/youtube-player-5.5.2.tgz#052b86b1eabe21ff331095ffffeae285fa7f7cb5"
+  integrity sha512-ZGtsemSpXnDky2AUYWgxjaopgB+shFHgXVpiJFeNB5nWEugpW1KWYDaHKuLqh2b67r24GtP6HoSW5swvf0fFIQ==
+  dependencies:
+    debug "^2.6.6"
+    load-script "^1.0.0"
+    sister "^3.0.0"
 
 zwitch@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
## What does this change?
Use `youtube-player` to simplify interations with youttube embed iframe API. This removes the need to worry about if and when the player has been initialised, and allows use to easily add and remove event emitters to the player without having to implement our own event emiter logic.

## How to test
Launch a video on storybook and check that it plays with and without overlay. You should see logs for each event we track on youtube but looking at the browser's console.

## Have we considered potential risks?
We now depend on the logic from `youtube-player`
