### PR TITLE
fix youtube atom

### DIFF
--- a/src/YoutubeAtom.test.tsx
+++ b/src/YoutubeAtom.test.tsx
@@ -47,10 +47,13 @@ describe('YoutubeAtom', () => {
                 e,
                 setHasUserLaunchedPlay,
                 eventEmitters,
-                // @ts-ignore
                 player: {
                     getCurrentTime,
                     getDuration,
+                    on: () => undefined,
+                    off: () => undefined,
+                    loadVideoById: () => undefined,
+                    playVideo: () => undefined,
                 },
             });
 
@@ -70,10 +73,13 @@ describe('YoutubeAtom', () => {
                 e,
                 setHasUserLaunchedPlay,
                 eventEmitters,
-                // @ts-ignore
                 player: {
                     getCurrentTime,
                     getDuration,
+                    on: () => undefined,
+                    off: () => undefined,
+                    loadVideoById: () => undefined,
+                    playVideo: () => undefined,
                 },
             });
 

--- a/src/YoutubeAtom.test.tsx
+++ b/src/YoutubeAtom.test.tsx
@@ -25,6 +25,7 @@ describe('YoutubeAtom', () => {
 
         expect(getByTitle('My Youtube video!')).toBeInTheDocument();
     });
+
     describe('onPlayerStateChangeAnalytics', () => {
         let setHasUserLaunchedPlay;
         let eventEmitters;
@@ -53,77 +54,11 @@ describe('YoutubeAtom', () => {
                 },
             });
 
-            jest.advanceTimersByTime(3000);
+            jest.advanceTimersByTime(1000);
             expect(eventEmitters[0]).toHaveBeenCalledTimes(1);
             expect(eventEmitters[0]).toHaveBeenCalledWith('play');
         });
 
-        it('should dispatch 25% watched event', () => {
-            const e = {
-                data: youtubePlayerState.PLAYING,
-            } as YoutubeStateChangeEventType;
-
-            const getCurrentTime = () => 25;
-            const getDuration = () => 100;
-            onPlayerStateChangeAnalytics({
-                e,
-                setHasUserLaunchedPlay,
-                eventEmitters,
-                // @ts-ignore
-                player: {
-                    getCurrentTime,
-                    getDuration,
-                },
-            });
-
-            jest.advanceTimersByTime(3000);
-            expect(eventEmitters[0]).toHaveBeenCalledTimes(1);
-            expect(eventEmitters[0]).toHaveBeenCalledWith('25');
-        });
-        it('should dispatch 50% watched event', () => {
-            const e = {
-                data: youtubePlayerState.PLAYING,
-            } as YoutubeStateChangeEventType;
-
-            const getCurrentTime = () => 50;
-            const getDuration = () => 100;
-            onPlayerStateChangeAnalytics({
-                e,
-                setHasUserLaunchedPlay,
-                eventEmitters,
-                // @ts-ignore
-                player: {
-                    getCurrentTime,
-                    getDuration,
-                },
-            });
-
-            jest.advanceTimersByTime(3000);
-            expect(eventEmitters[0]).toHaveBeenCalledTimes(1);
-            expect(eventEmitters[0]).toHaveBeenCalledWith('50');
-        });
-        it('should dispatch 75% watched event', () => {
-            const e = {
-                data: youtubePlayerState.PLAYING,
-            } as YoutubeStateChangeEventType;
-
-            const getCurrentTime = () => 75;
-            const getDuration = () => 100;
-            onPlayerStateChangeAnalytics({
-                e,
-                setHasUserLaunchedPlay,
-                eventEmitters,
-                // @ts-ignore
-                player: {
-                    getCurrentTime,
-                    getDuration,
-                },
-            });
-
-            jest.advanceTimersByTime(3000);
-            expect(eventEmitters[0]).toHaveBeenCalledTimes(1);
-            expect(eventEmitters[0]).toHaveBeenCalledWith('75');
-        });
         it('should dispatch end event', () => {
             const e = {
                 data: youtubePlayerState.ENDED,

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -112,9 +112,6 @@ export const onPlayerStateChangeAnalytics = ({
     eventEmitters: ((event: VideoEventKey) => void)[];
     player: YoutubePlayerType;
 }): void => {
-    console.log('e.data');
-    console.log(e.data);
-
     switch (e.data) {
         case youtubePlayerState.PLAYING: {
             setHasUserLaunchedPlay(true);
@@ -130,8 +127,6 @@ export const onPlayerStateChangeAnalytics = ({
             // NOTE: you will not be able to set React state in setInterval
             // https://overreacted.io/making-setinterval-declarative-with-react-hooks/
             progressTracker = setInterval(async () => {
-                console.log('setInterval called');
-
                 const currentTime = await player.getCurrentTime();
                 const duration = await player.getDuration();
 

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -138,7 +138,6 @@ export const onPlayerStateChangeAnalytics = ({
                     (currentTime / duration) * 100,
                 ) as number;
 
-                // Used to check and dispatch event if 25/50/75% progress made on video
                 if (
                     `${percentPlayed}` in eventState &&
                     !eventState[percentPlayed]
@@ -274,11 +273,11 @@ export const YoutubeAtom = ({
     const [hasUserLaunchedPlay, setHasUserLaunchedPlay] = useState<boolean>(
         false,
     );
-    if (!player && typeof window !== 'undefined') {
-        player = YouTubePlayer(`youtube-video-${videoMeta.assetId}`);
-    }
 
     useEffect(() => {
+        if (!player && typeof window !== 'undefined') {
+            player = YouTubePlayer(`youtube-video-${videoMeta.assetId}`);
+        }
         const listener = player?.on(
             'stateChange',
             (e: YT.PlayerEvent & YoutubeStateChangeEventType) => {

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState } from 'react';
 import { css, cx } from 'emotion';
 import YouTubePlayer from 'youtube-player';
 

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -275,7 +275,7 @@ export const YoutubeAtom = ({
     );
 
     useEffect(() => {
-        if (!player && typeof window !== 'undefined') {
+        if (!player) {
             player = YouTubePlayer(`youtube-video-${videoMeta.assetId}`);
         }
         const listener = player?.on(

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -96,9 +96,9 @@ let progressTracker: NodeJS.Timeout | null;
 const eventState: { [key: string]: boolean } = {
     play: false,
     end: false,
-    25: false,
-    50: false,
-    75: false,
+    '25': false,
+    '50': false,
+    '75': false,
 };
 
 export const onPlayerStateChangeAnalytics = ({
@@ -112,6 +112,9 @@ export const onPlayerStateChangeAnalytics = ({
     eventEmitters: ((event: VideoEventKey) => void)[];
     player: YoutubePlayerType;
 }): void => {
+    console.log('e.data');
+    console.log(e.data);
+
     switch (e.data) {
         case youtubePlayerState.PLAYING: {
             setHasUserLaunchedPlay(true);
@@ -121,11 +124,16 @@ export const onPlayerStateChangeAnalytics = ({
                 eventState['play'] = true;
             }
 
+            // Need to remove previous setInterval if already exists
+            if (progressTracker) clearInterval(progressTracker);
+
             // NOTE: you will not be able to set React state in setInterval
             // https://overreacted.io/making-setinterval-declarative-with-react-hooks/
-            progressTracker = setInterval(() => {
-                const currentTime = player.getCurrentTime();
-                const duration = player.getDuration();
+            progressTracker = setInterval(async () => {
+                console.log('setInterval called');
+
+                const currentTime = await player.getCurrentTime();
+                const duration = await player.getDuration();
 
                 // Note that getDuration() will return 0 until the video's metadata is loaded
                 // which normally happens just after the video starts playing.
@@ -136,13 +144,16 @@ export const onPlayerStateChangeAnalytics = ({
                 ) as number;
 
                 // Used to check and dispatch event if 25/50/75% progress made on video
-                if (percentPlayed in eventState && !eventState[percentPlayed]) {
+                if (
+                    `${percentPlayed}` in eventState &&
+                    !eventState[percentPlayed]
+                ) {
                     eventEmitters.forEach((eventEmitter) =>
                         eventEmitter(`${percentPlayed}` as VideoEventKey),
                     );
                     eventState[percentPlayed] = true;
                 }
-            }, 1000);
+            }, 500);
             break;
         }
         case youtubePlayerState.PAUSED: {
@@ -155,7 +166,9 @@ export const onPlayerStateChangeAnalytics = ({
                 eventEmitters.forEach((eventEmitter) => eventEmitter('end'));
                 eventState['end'] = true;
             }
+
             progressTracker && clearInterval(progressTracker);
+            break;
         }
     }
 };
@@ -244,6 +257,7 @@ type YoutubePlayerType = {
     getDuration: () => number;
 };
 
+let player: YoutubePlayerType | undefined;
 // Note, this is a subset of the CAPI MediaAtom essentially.
 export const YoutubeAtom = ({
     videoMeta,
@@ -265,29 +279,26 @@ export const YoutubeAtom = ({
     const [hasUserLaunchedPlay, setHasUserLaunchedPlay] = useState<boolean>(
         false,
     );
-    const player = useRef<YoutubePlayerType>();
+    if (!player && typeof window !== 'undefined') {
+        player = YouTubePlayer(`youtube-video-${videoMeta.assetId}`);
+    }
 
     useEffect(() => {
-        if (!player.current)
-            player.current = YouTubePlayer(
-                `youtube-video-${videoMeta.assetId}`,
-            );
-
-        const listener = player?.current?.on(
+        const listener = player?.on(
             'stateChange',
             (e: YT.PlayerEvent & YoutubeStateChangeEventType) => {
-                if (player.current) {
+                if (player) {
                     onPlayerStateChangeAnalytics({
                         e,
                         setHasUserLaunchedPlay,
                         eventEmitters,
-                        player: player.current,
+                        player,
                     });
                 }
             },
         );
 
-        return () => listener && player?.current?.off(listener);
+        return () => listener && player?.off(listener);
     }, [eventEmitters]);
 
     return (
@@ -306,12 +317,12 @@ export const YoutubeAtom = ({
 
             {(overlayImage || posterImage) && (
                 <div
-                    onClick={() => player?.current?.playVideo()}
+                    onClick={() => player?.playVideo()}
                     onKeyDown={(e) => {
                         const spaceKey = 32;
                         const enterKey = 13;
                         if (e.keyCode === spaceKey || e.keyCode === enterKey)
-                            player?.current?.playVideo();
+                            player?.playVideo();
                     }}
                     className={cx(
                         overlayStyles,


### PR DESCRIPTION
## What does this change?
Adds some fixes to issues that appeared during DCR integration:

- convert`eventState` keys to string to help check
- add `await` to `player.getCurrentTime` and `player.getDuration`
- reduce interval from 1s to 0.5s (because we are using `async` `await` we risk skipping a second)
- use `let player` outside component, checking if has been defined before init

## Have we considered potential risks?
Potential unforseen race conditions
