### PR TITLE
Remove interval logic youtube progress tracker

### DIFF
--- a/src/YoutubeAtom.test.tsx
+++ b/src/YoutubeAtom.test.tsx
@@ -27,12 +27,10 @@ describe('YoutubeAtom', () => {
     });
 
     describe('onPlayerStateChangeAnalytics', () => {
-        let setHasUserLaunchedPlay;
         let eventEmitters;
 
         beforeEach(() => {
             jest.useFakeTimers();
-            setHasUserLaunchedPlay = jest.fn();
             eventEmitters = [jest.fn()];
         });
 
@@ -45,7 +43,6 @@ describe('YoutubeAtom', () => {
             const getDuration = () => 100;
             onPlayerStateChangeAnalytics({
                 e,
-                setHasUserLaunchedPlay,
                 eventEmitters,
                 player: {
                     getCurrentTime,
@@ -55,6 +52,12 @@ describe('YoutubeAtom', () => {
                     loadVideoById: () => undefined,
                     playVideo: () => undefined,
                 },
+                eventState: {
+                    play: false,
+                    end: false,
+                },
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                setEventState: () => {},
             });
 
             jest.advanceTimersByTime(1000);
@@ -71,7 +74,6 @@ describe('YoutubeAtom', () => {
             const getDuration = () => 100;
             onPlayerStateChangeAnalytics({
                 e,
-                setHasUserLaunchedPlay,
                 eventEmitters,
                 player: {
                     getCurrentTime,
@@ -81,6 +83,12 @@ describe('YoutubeAtom', () => {
                     loadVideoById: () => undefined,
                     playVideo: () => undefined,
                 },
+                eventState: {
+                    play: false,
+                    end: false,
+                },
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                setEventState: () => {},
             });
 
             expect(eventEmitters[0]).toHaveBeenCalledWith('end');

--- a/src/YoutubeAtom.test.tsx
+++ b/src/YoutubeAtom.test.tsx
@@ -7,15 +7,22 @@ import {
     YoutubeAtom,
     onPlayerStateChangeAnalytics,
     youtubePlayerState,
+    initSharedYTData,
+    sharedYTData,
 } from './YoutubeAtom';
 
+const assetId = '-ZCvZmYlQD8';
 describe('YoutubeAtom', () => {
+    beforeAll(() => {
+        sharedYTData[assetId] = initSharedYTData;
+    });
+
     it('should render', () => {
         const atom = (
             <YoutubeAtom
                 title="My Youtube video!"
                 videoMeta={{
-                    assetId: '-ZCvZmYlQD8',
+                    assetId,
                     mediaTitle: 'YoutubeAtom',
                 }}
                 eventEmitters={[]}
@@ -52,12 +59,7 @@ describe('YoutubeAtom', () => {
                     loadVideoById: () => undefined,
                     playVideo: () => undefined,
                 },
-                eventState: {
-                    play: false,
-                    end: false,
-                },
-                // eslint-disable-next-line @typescript-eslint/no-empty-function
-                setEventState: () => {},
+                assetId,
             });
 
             jest.advanceTimersByTime(1000);
@@ -83,12 +85,7 @@ describe('YoutubeAtom', () => {
                     loadVideoById: () => undefined,
                     playVideo: () => undefined,
                 },
-                eventState: {
-                    play: false,
-                    end: false,
-                },
-                // eslint-disable-next-line @typescript-eslint/no-empty-function
-                setEventState: () => {},
+                assetId,
             });
 
             expect(eventEmitters[0]).toHaveBeenCalledWith('end');

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -110,28 +110,24 @@ const intervalProgressTracker = async ({
     const percentPlayed = ((currentTime / duration) * 100) as number;
 
     if (pastProgressPercentage < 25 && 25 < percentPlayed) {
-        pastProgressPercentage = percentPlayed;
-
         eventEmitters.forEach((eventEmitter) =>
             eventEmitter('25' as VideoEventKey),
         );
     }
 
     if (pastProgressPercentage < 50 && 50 < percentPlayed) {
-        pastProgressPercentage = percentPlayed;
-
         eventEmitters.forEach((eventEmitter) =>
             eventEmitter('50' as VideoEventKey),
         );
     }
 
     if (pastProgressPercentage < 75 && 75 < percentPlayed) {
-        pastProgressPercentage = percentPlayed;
-
         eventEmitters.forEach((eventEmitter) =>
             eventEmitter('75' as VideoEventKey),
         );
     }
+
+    pastProgressPercentage = percentPlayed;
 
     // we recursively set set timeout as a way of only having one interval at a time querying
     progressTrackerTimoutId = window.setTimeout(

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -147,7 +147,7 @@ export const onPlayerStateChangeAnalytics = ({
                     );
                     eventState[percentPlayed] = true;
                 }
-            }, 500);
+            }, 200);
             break;
         }
         case youtubePlayerState.PAUSED: {

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -345,7 +345,6 @@ export const YoutubeAtom = ({
                         player.current?.playVideo();
                     }}
                     onKeyDown={(e) => {
-                        true;
                         const spaceKey = 32;
                         const enterKey = 13;
                         if (e.keyCode === spaceKey || e.keyCode === enterKey)

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -95,13 +95,13 @@ type sharedYTDataType = {
     pastProgressPercentage: number;
     hasPlayEventBeenFired: boolean;
 };
-const initSharedYTData: sharedYTDataType = {
+export const initSharedYTData: sharedYTDataType = {
     progressTrackerTimoutId: undefined,
     pastProgressPercentage: 0,
     hasPlayEventBeenFired: false,
 };
 
-let sharedYTData: {
+export let sharedYTData: {
     [key: string]: sharedYTDataType;
 } = {};
 
@@ -199,6 +199,8 @@ export const onPlayerStateChangeAnalytics = ({
                 clearTimeout(sharedYTData[assetId].progressTrackerTimoutId);
                 sharedYTData[assetId].progressTrackerTimoutId = undefined;
             }
+
+            eventEmitters.forEach((eventEmitter) => eventEmitter('end'));
 
             // reset data
             sharedYTData = {


### PR DESCRIPTION
## What does this change?
- instead of using `setInterval` we recursively use `setTimeout`
The enforces that only 1 interval/script is being called at a time.

- use a previous percentage varible to track difference with current and previous percentage progress 
Previously we would have to call every second (or even more often as you cannot ensure promises would resolve at a specified time) to check the progress of a video. But if we have a previous variable, all we check is the current percentage with the previous and then dispatch events based on the difference. 


- use some shared global state for videos outside of the react component
We have to add and remove `listener` to the player during re-renders. However we want to persiste some data to track thinkgs like: has the play event been disptahced? what was the previous percentage progres? is there a recursive timeout already running?
Setting all of these within the react component would force use to have to re-render. To avoid re-renders we have a mutable object called `sharedYTData` and in order for one YT video not to override the data of another, we added a unique key based on assetId.
