### PR TITLE
Youtube progress tracker interval v2

### DIFF
--- a/src/YoutubeAtom.test.tsx
+++ b/src/YoutubeAtom.test.tsx
@@ -27,12 +27,10 @@ describe('YoutubeAtom', () => {
     });
 
     describe('onPlayerStateChangeAnalytics', () => {
-        let setHasUserLaunchedPlay;
         let eventEmitters;
 
         beforeEach(() => {
             jest.useFakeTimers();
-            setHasUserLaunchedPlay = jest.fn();
             eventEmitters = [jest.fn()];
         });
 
@@ -45,7 +43,6 @@ describe('YoutubeAtom', () => {
             const getDuration = () => 100;
             onPlayerStateChangeAnalytics({
                 e,
-                setHasUserLaunchedPlay,
                 eventEmitters,
                 player: {
                     getCurrentTime,
@@ -55,6 +52,12 @@ describe('YoutubeAtom', () => {
                     loadVideoById: () => undefined,
                     playVideo: () => undefined,
                 },
+                eventState: {
+                    play: false,
+                    end: false,
+                },
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                setEventState: () => {},
             });
 
             jest.advanceTimersByTime(1000);
@@ -71,7 +74,6 @@ describe('YoutubeAtom', () => {
             const getDuration = () => 100;
             onPlayerStateChangeAnalytics({
                 e,
-                setHasUserLaunchedPlay,
                 eventEmitters,
                 player: {
                     getCurrentTime,
@@ -81,6 +83,12 @@ describe('YoutubeAtom', () => {
                     loadVideoById: () => undefined,
                     playVideo: () => undefined,
                 },
+                eventState: {
+                    play: false,
+                    end: false,
+                },
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                setEventState: () => {},
             });
 
             expect(eventEmitters[0]).toHaveBeenCalledWith('end');

--- a/src/YoutubeAtom.test.tsx
+++ b/src/YoutubeAtom.test.tsx
@@ -7,15 +7,22 @@ import {
     YoutubeAtom,
     onPlayerStateChangeAnalytics,
     youtubePlayerState,
+    initSharedYTData,
+    sharedYTData,
 } from './YoutubeAtom';
 
+const assetId = '-ZCvZmYlQD8';
 describe('YoutubeAtom', () => {
+    beforeAll(() => {
+        sharedYTData[assetId] = initSharedYTData;
+    });
+
     it('should render', () => {
         const atom = (
             <YoutubeAtom
                 title="My Youtube video!"
                 videoMeta={{
-                    assetId: '-ZCvZmYlQD8',
+                    assetId,
                     mediaTitle: 'YoutubeAtom',
                 }}
                 eventEmitters={[]}
@@ -52,12 +59,7 @@ describe('YoutubeAtom', () => {
                     loadVideoById: () => undefined,
                     playVideo: () => undefined,
                 },
-                eventState: {
-                    play: false,
-                    end: false,
-                },
-                // eslint-disable-next-line @typescript-eslint/no-empty-function
-                setEventState: () => {},
+                assetId,
             });
 
             jest.advanceTimersByTime(1000);
@@ -83,12 +85,7 @@ describe('YoutubeAtom', () => {
                     loadVideoById: () => undefined,
                     playVideo: () => undefined,
                 },
-                eventState: {
-                    play: false,
-                    end: false,
-                },
-                // eslint-disable-next-line @typescript-eslint/no-empty-function
-                setEventState: () => {},
+                assetId,
             });
 
             expect(eventEmitters[0]).toHaveBeenCalledWith('end');

--- a/src/YoutubeAtom.test.tsx
+++ b/src/YoutubeAtom.test.tsx
@@ -2,21 +2,10 @@ import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { render } from '@testing-library/react';
 
-import { YoutubeStateChangeEventType } from './types';
-import {
-    YoutubeAtom,
-    onPlayerStateChangeAnalytics,
-    youtubePlayerState,
-    initSharedYTData,
-    sharedYTData,
-} from './YoutubeAtom';
+import { YoutubeAtom } from './YoutubeAtom';
 
 const assetId = '-ZCvZmYlQD8';
 describe('YoutubeAtom', () => {
-    beforeAll(() => {
-        sharedYTData[assetId] = initSharedYTData;
-    });
-
     it('should render', () => {
         const atom = (
             <YoutubeAtom
@@ -31,64 +20,5 @@ describe('YoutubeAtom', () => {
         const { getByTitle } = render(atom);
 
         expect(getByTitle('My Youtube video!')).toBeInTheDocument();
-    });
-
-    describe('onPlayerStateChangeAnalytics', () => {
-        let eventEmitters;
-
-        beforeEach(() => {
-            jest.useFakeTimers();
-            eventEmitters = [jest.fn()];
-        });
-
-        it('should dispatch play (start) event', () => {
-            const e = {
-                data: youtubePlayerState.PLAYING,
-            } as YoutubeStateChangeEventType;
-
-            const getCurrentTime = () => 15;
-            const getDuration = () => 100;
-            onPlayerStateChangeAnalytics({
-                e,
-                eventEmitters,
-                player: {
-                    getCurrentTime,
-                    getDuration,
-                    on: () => undefined,
-                    off: () => undefined,
-                    loadVideoById: () => undefined,
-                    playVideo: () => undefined,
-                },
-                assetId,
-            });
-
-            jest.advanceTimersByTime(1000);
-            expect(eventEmitters[0]).toHaveBeenCalledTimes(1);
-            expect(eventEmitters[0]).toHaveBeenCalledWith('play');
-        });
-
-        it('should dispatch end event', () => {
-            const e = {
-                data: youtubePlayerState.ENDED,
-            } as YoutubeStateChangeEventType;
-
-            const getCurrentTime = () => 100;
-            const getDuration = () => 100;
-            onPlayerStateChangeAnalytics({
-                e,
-                eventEmitters,
-                player: {
-                    getCurrentTime,
-                    getDuration,
-                    on: () => undefined,
-                    off: () => undefined,
-                    loadVideoById: () => undefined,
-                    playVideo: () => undefined,
-                },
-                assetId,
-            });
-
-            expect(eventEmitters[0]).toHaveBeenCalledWith('end');
-        });
     });
 });

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -9,7 +9,6 @@ import { SvgPlay } from '@guardian/src-icons';
 
 import { MaintainAspectRatio } from './common/MaintainAspectRatio';
 import { formatTime } from './lib/formatTime';
-import { YoutubeStateChangeEventType } from './types';
 
 type Props = {
     videoMeta: YoutubeMeta;
@@ -28,6 +27,8 @@ declare global {
         onYouTubeIframeAPIReady: unknown;
     }
 }
+
+type YoutubeStateChangeEventType = { data: -1 | 0 | 1 | 2 | 3 | 5 };
 
 type EmbedConfig = {
     adsConfig: {

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -110,28 +110,24 @@ const intervalProgressTracker = async ({
     const percentPlayed = ((currentTime / duration) * 100) as number;
 
     if (pastProgressPercentage < 25 && 25 < percentPlayed) {
-        pastProgressPercentage = percentPlayed;
-
         eventEmitters.forEach((eventEmitter) =>
             eventEmitter('25' as VideoEventKey),
         );
     }
 
     if (pastProgressPercentage < 50 && 50 < percentPlayed) {
-        pastProgressPercentage = percentPlayed;
-
         eventEmitters.forEach((eventEmitter) =>
             eventEmitter('50' as VideoEventKey),
         );
     }
 
     if (pastProgressPercentage < 75 && 75 < percentPlayed) {
-        pastProgressPercentage = percentPlayed;
-
         eventEmitters.forEach((eventEmitter) =>
             eventEmitter('75' as VideoEventKey),
         );
     }
+
+    pastProgressPercentage = percentPlayed;
 
     // we recursively set set timeout as a way of only having one interval at a time querying
     progressTrackerTimoutId = window.setTimeout(

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -238,21 +238,21 @@ export const YoutubeAtom = ({
 
                         if (!hasSent25Event && 25 < percentPlayed) {
                             eventEmitters.forEach((eventEmitter) =>
-                                eventEmitter('25' as VideoEventKey),
+                                eventEmitter('25'),
                             );
                             hasSent25Event = true;
                         }
 
                         if (!hasSent50Event && 50 < percentPlayed) {
                             eventEmitters.forEach((eventEmitter) =>
-                                eventEmitter('50' as VideoEventKey),
+                                eventEmitter('50'),
                             );
                             hasSent50Event = true;
                         }
 
                         if (!hasSent75Event && 75 < percentPlayed) {
                             eventEmitters.forEach((eventEmitter) =>
-                                eventEmitter('75' as VideoEventKey),
+                                eventEmitter('75'),
                             );
                             hasSent75Event = true;
                         }

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -147,7 +147,7 @@ export const onPlayerStateChangeAnalytics = ({
                     );
                     eventState[percentPlayed] = true;
                 }
-            }, 500);
+            }, 200);
             break;
         }
         case youtubePlayerState.PAUSED: {

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -345,7 +345,6 @@ export const YoutubeAtom = ({
                         player.current?.playVideo();
                     }}
                     onKeyDown={(e) => {
-                        true;
                         const spaceKey = 32;
                         const enterKey = 13;
                         if (e.keyCode === spaceKey || e.keyCode === enterKey)

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -233,8 +233,7 @@ export const YoutubeAtom = ({
 
                         if (!duration || !currentTime) return;
 
-                        const percentPlayed = ((currentTime / duration) *
-                            100) as number;
+                        const percentPlayed = (currentTime / duration) * 100;
 
                         if (!hasSent25Event && 25 < percentPlayed) {
                             eventEmitters.forEach((eventEmitter) =>

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -302,8 +302,10 @@ export const YoutubeAtom = ({
                     onKeyDown={(e) => {
                         const spaceKey = 32;
                         const enterKey = 13;
-                        if (e.keyCode === spaceKey || e.keyCode === enterKey)
+                        if (e.keyCode === spaceKey || e.keyCode === enterKey) {
+                            setHasUserLaunchedPlay(true);
                             player.current?.playVideo();
+                        }
                     }}
                     className={cx(
                         overlayStyles,

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -95,13 +95,13 @@ type sharedYTDataType = {
     pastProgressPercentage: number;
     hasPlayEventBeenFired: boolean;
 };
-const initSharedYTData: sharedYTDataType = {
+export const initSharedYTData: sharedYTDataType = {
     progressTrackerTimoutId: undefined,
     pastProgressPercentage: 0,
     hasPlayEventBeenFired: false,
 };
 
-let sharedYTData: {
+export let sharedYTData: {
     [key: string]: sharedYTDataType;
 } = {};
 
@@ -199,6 +199,8 @@ export const onPlayerStateChangeAnalytics = ({
                 clearTimeout(sharedYTData[assetId].progressTrackerTimoutId);
                 sharedYTData[assetId].progressTrackerTimoutId = undefined;
             }
+
+            eventEmitters.forEach((eventEmitter) => eventEmitter('end'));
 
             // reset data
             sharedYTData = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,8 +6,6 @@ export type AdTargeting = {
     customParams: { [key: string]: any };
 };
 
-export type YoutubeStateChangeEventType = { data: -1 | 0 | 1 | 2 | 3 | 5 };
-
 export type AudioAtomType = {
     id: string;
     trackUrl: string;


### PR DESCRIPTION
## What does this change?
- Use `useRef` to store player state
- Remove `onPlayerStateChangeAnalytics`  and instead move event dispatch logic all into useEffect.
- Simplify logic by moving boolean checks of it events dispatched to be within useEffect and not in or out of component state


## How to test
On storybook, play through videos and in console check the events are all fired when they hit specific percentages (and that they are only fired once)

## Have we considered potential risks?
The useEffect is rerendered when eventEmitters changes. This means that events could be retriggered if that object changes. However it is likely that eventEmitters will change at most once, and will likely be done before the user plays the video. So there would be low to no impact.
