### PR TITLE
Fix accessiblity audio atom

### DIFF
--- a/src/AudioAtom.tsx
+++ b/src/AudioAtom.tsx
@@ -357,7 +357,9 @@ export const AudioAtom = ({
                     </audio>
                     <div className={audioControlsStyle}>
                         <button
-                            data-testid="play-button"
+                            data-testid={
+                                isPlaying ? 'pause-button' : 'play-button'
+                            }
                             onClick={() =>
                                 isPlaying ? pauseAudio() : playAudio()
                             }

--- a/src/AudioAtom.tsx
+++ b/src/AudioAtom.tsx
@@ -160,68 +160,48 @@ const formatTime = (t: number) => {
     return `${format(hour)}:${format(minute)}:${format(second)}`;
 };
 
-const PauseButton = ({
-    onClick,
-    pillar,
-}: {
-    onClick: () => void;
-    pillar: Pillar;
-}) => (
-    <button
-        data-testid="pause-button"
-        onClick={onClick}
-        className={buttonStyle}
+const PauseSVG = ({ pillar }: { pillar: Pillar }) => (
+    <svg
+        className={svgPauseStyle}
+        width="30px"
+        height="30px"
+        viewBox="0 0 30 30"
     >
-        <svg
-            className={svgPauseStyle}
-            width="30px"
-            height="30px"
-            viewBox="0 0 30 30"
-        >
-            <g fill="none" fillRule="evenodd">
-                <circle
-                    fill={pillarPalette[pillar][400]}
-                    cx="15"
-                    cy="15"
-                    r="15"
-                ></circle>
-                <path
-                    d="M9.429 7.286h3.429v15.429h-3.43zm7.286 0h3.429v15.429h-3.43z"
-                    fill={palette.neutral[100]}
-                ></path>
-            </g>
-        </svg>
-    </button>
+        <g fill="none" fillRule="evenodd">
+            <circle
+                fill={pillarPalette[pillar][400]}
+                cx="15"
+                cy="15"
+                r="15"
+            ></circle>
+            <path
+                d="M9.429 7.286h3.429v15.429h-3.43zm7.286 0h3.429v15.429h-3.43z"
+                fill={palette.neutral[100]}
+            ></path>
+        </g>
+    </svg>
 );
 
-const PlayButton = ({
-    onClick,
-    pillar,
-}: {
-    onClick: () => void;
-    pillar: Pillar;
-}) => (
-    <button data-testid="play-button" onClick={onClick} className={buttonStyle}>
-        <svg
-            className={svgPlayStyle}
-            width="30px"
-            height="30px"
-            viewBox="0 0 30 30"
-        >
-            <g fill="none" fillRule="evenodd">
-                <circle
-                    fill={pillarPalette[pillar][400]}
-                    cx="15"
-                    cy="15"
-                    r="15"
-                ></circle>
-                <path
-                    fill={palette.neutral[100]}
-                    d="M10.113 8.571l-.47.366V20.01l.472.347 13.456-5.593v-.598z"
-                ></path>
-            </g>
-        </svg>
-    </button>
+const PlaySVG = ({ pillar }: { pillar: Pillar }) => (
+    <svg
+        className={svgPlayStyle}
+        width="30px"
+        height="30px"
+        viewBox="0 0 30 30"
+    >
+        <g fill="none" fillRule="evenodd">
+            <circle
+                fill={pillarPalette[pillar][400]}
+                cx="15"
+                cy="15"
+                r="15"
+            ></circle>
+            <path
+                fill={palette.neutral[100]}
+                d="M10.113 8.571l-.47.366V20.01l.472.347 13.456-5.593v-.598z"
+            ></path>
+        </g>
+    </svg>
 );
 
 const buildUrl = (basicUrl: string, shouldUseAcast?: boolean) => {
@@ -335,6 +315,16 @@ export const AudioAtom = ({
         setUrlToUse(buildUrl(trackUrl, shouldUseAcast));
     }, [shouldUseAcast]);
 
+    const playAudio = () => {
+        setIsPlaying(true);
+        audioEl.current && audioEl.current.play();
+    };
+
+    const pauseAudio = () => {
+        setIsPlaying(false);
+        audioEl.current && audioEl.current.pause();
+    };
+
     return (
         <figure
             className={figureStyle}
@@ -366,23 +356,19 @@ export const AudioAtom = ({
                         </p>
                     </audio>
                     <div className={audioControlsStyle}>
-                        {isPlaying ? (
-                            <PauseButton
-                                pillar={pillar}
-                                onClick={() => {
-                                    setIsPlaying(false);
-                                    audioEl.current && audioEl.current.pause();
-                                }}
-                            />
-                        ) : (
-                            <PlayButton
-                                pillar={pillar}
-                                onClick={() => {
-                                    audioEl.current && audioEl.current.play();
-                                    setIsPlaying(true);
-                                }}
-                            />
-                        )}
+                        <button
+                            data-testid="play-button"
+                            onClick={() =>
+                                isPlaying ? pauseAudio() : playAudio()
+                            }
+                            className={buttonStyle}
+                        >
+                            {isPlaying ? (
+                                <PauseSVG pillar={pillar} />
+                            ) : (
+                                <PlaySVG pillar={pillar} />
+                            )}
+                        </button>
                     </div>
                     <div className={timingStyle}>
                         <div className={timePlayedStyle}>


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
When toggling the play and pause buttons in Audio Atoms we would loose focus on the button because it would rerender.

To keep focus, we lift the button DOM element to only toggle the onClick and the child SVG, thus keeping the button DOM. Doing this allows us to keep focus on the button while toggling. 

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Storybook use keyboard to launch audio atom

