### PR TITLE
Reset knowledge quiz correctly

### DIFF
--- a/src/Answers.tsx
+++ b/src/Answers.tsx
@@ -87,6 +87,7 @@ const AnswerWithSVG = ({
             )}
             data-answertype={answertype}
             required
+            tabIndex={-1}
         />
         <label
             className={css`
@@ -124,6 +125,7 @@ const AnswerWithoutSVG = ({
     name,
     isCorrect,
     answertype,
+    hasBeenAnswered,
 }: {
     id: string;
     text: string;
@@ -131,6 +133,7 @@ const AnswerWithoutSVG = ({
     name: string;
     isCorrect?: boolean;
     answertype: string;
+    hasBeenAnswered: boolean;
 }): JSX.Element => (
     <div
         className={css`
@@ -160,6 +163,7 @@ const AnswerWithoutSVG = ({
             )}
             data-answertype={answertype}
             required
+            tabIndex={hasBeenAnswered ? -1 : 0}
         />
         <label
             className={css`
@@ -206,6 +210,7 @@ export const CorrectSelectedAnswer = ({
         supplementText={explainerText}
         isCorrect={true}
         answertype="correct-selected-answer"
+        hasBeenAnswered={true}
     />
 );
 
@@ -262,5 +267,6 @@ export const UnselectedAnswer = ({
         name={name}
         text={answerText}
         answertype="unselected-disabled-answer"
+        hasBeenAnswered={false}
     />
 );

--- a/src/KnowledgeQuiz.tsx
+++ b/src/KnowledgeQuiz.tsx
@@ -43,6 +43,10 @@ export const KnowledgeQuizAtom = ({
     id,
     questions,
 }: QuizAtomType): JSX.Element => {
+    const [selectedAnswers, setSelectedAnswers] = useState<{
+        [key: string]: string;
+    }>({});
+
     const [hasSubmittedAnswers, setHasSubmittedAnswers] = useState<boolean>(
         false,
     );
@@ -58,6 +62,13 @@ export const KnowledgeQuizAtom = ({
                         imageUrl={question.imageUrl}
                         answers={question.answers}
                         hasSubmittedAnswers={hasSubmittedAnswers}
+                        selectedAnswers={selectedAnswers}
+                        updateSelectedAnswer={(selectedAnswerId: string) => {
+                            setSelectedAnswers({
+                                ...selectedAnswers,
+                                [question.id]: selectedAnswerId,
+                            });
+                        }}
                     />
                 ))}
             </form>
@@ -85,12 +96,17 @@ export const KnowledgeQuizAtom = ({
                 </Button>
                 <Button
                     priority="secondary"
-                    onClick={() => setHasSubmittedAnswers(false)}
+                    onClick={() => {
+                        setHasSubmittedAnswers(false);
+                        setSelectedAnswers({});
+                    }}
                     onKeyDown={(e) => {
                         const spaceKey = 32;
                         const enterKey = 13;
-                        if (e.keyCode === spaceKey || e.keyCode === enterKey)
+                        if (e.keyCode === spaceKey || e.keyCode === enterKey) {
                             setHasSubmittedAnswers(false);
+                            setSelectedAnswers({});
+                        }
                     }}
                     data-testid="reset-quiz"
                 >
@@ -108,9 +124,15 @@ export const Question = ({
     answers,
     number,
     hasSubmittedAnswers,
+    selectedAnswers,
+    updateSelectedAnswer,
 }: QuestionType & {
     number: number;
     hasSubmittedAnswers: boolean;
+    selectedAnswers: {
+        [key: string]: string;
+    };
+    updateSelectedAnswer: (selectedAnswerId: string) => void;
 }): JSX.Element => (
     <div
         className={css`
@@ -152,6 +174,8 @@ export const Question = ({
                     id={id}
                     answers={answers}
                     hasSubmittedAnswers={hasSubmittedAnswers}
+                    selectedAnswers={selectedAnswers}
+                    updateSelectedAnswer={updateSelectedAnswer}
                 />
             </div>
         </fieldset>
@@ -162,18 +186,23 @@ const Answers = ({
     answers,
     id: questionId,
     hasSubmittedAnswers,
+    selectedAnswers,
+    updateSelectedAnswer,
 }: {
     answers: AnswerType[];
     id: string;
     hasSubmittedAnswers: boolean;
+    selectedAnswers: {
+        [key: string]: string;
+    };
+    updateSelectedAnswer: (selectedAnswerId: string) => void;
 }) => {
-    const [selected, setSelected] = useState<string | undefined>(undefined);
-
     if (hasSubmittedAnswers) {
         return (
             <Fragment>
                 {answers.map((answer) => {
-                    const isSelected = selected === answer.id;
+                    const isSelected =
+                        selectedAnswers[questionId] === answer.id;
 
                     if (isSelected) {
                         if (answer.isCorrect) {
@@ -234,14 +263,14 @@ const Answers = ({
                         value={answer.text}
                         data-testid={answer.id}
                         data-answertype={
-                            selected === answer.id
+                            selectedAnswers[questionId] === answer.id
                                 ? 'selected-enabled-answer'
                                 : 'unselected-enabled-answer'
                         }
                         name={questionId}
                         label={answer.text}
-                        onChange={() => setSelected(answer.id)}
-                        checked={selected === answer.id}
+                        onChange={() => updateSelectedAnswer(answer.id)}
+                        checked={selectedAnswers[questionId] === answer.id}
                     />
                 ))}
             </RadioGroup>


### PR DESCRIPTION
## What does this change?
Lift selected answers state logic to parent to enable reset button to clear previous quiz selection

## Before
![2020-12-29 14 36 44](https://user-images.githubusercontent.com/8831403/103291317-5bb62680-49e3-11eb-8de1-18c0c4cb1732.gif)

## After
![2020-12-29 14 35 28](https://user-images.githubusercontent.com/8831403/103291328-5fe24400-49e3-11eb-9633-79968037461a.gif)

