### PR TITLE
Pillar (with labs)

### DIFF
--- a/src/AudioAtom.stories.tsx
+++ b/src/AudioAtom.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 
-import { Pillar } from '@guardian/types/Format';
+import { Pillar } from './types';
 
 import { AudioAtom } from './AudioAtom';
 

--- a/src/AudioAtom.test.tsx
+++ b/src/AudioAtom.test.tsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect';
 import { render } from '@testing-library/react';
 import { screen, fireEvent } from '@testing-library/dom';
 
-import { Pillar } from '@guardian/types/Format';
+import { Pillar } from './types';
 
 import { AudioAtom } from './AudioAtom';
 

--- a/src/AudioAtom.tsx
+++ b/src/AudioAtom.tsx
@@ -3,11 +3,10 @@ import { css } from 'emotion';
 
 import { textSans, headline } from '@guardian/src-foundations/typography';
 import { palette } from '@guardian/src-foundations';
-import { Pillar } from '@guardian/types/Format';
 import { focusHalo } from '@guardian/src-foundations/accessibility';
 
 import { pillarPalette } from './lib/pillarPalette';
-import { AudioAtomType } from './types';
+import { AudioAtomType, Pillar } from './types';
 
 const wrapperStyles = css`
     width: 100%;

--- a/src/lib/pillarPalette.ts
+++ b/src/lib/pillarPalette.ts
@@ -1,4 +1,3 @@
-import { Pillar } from '@guardian/types/Format';
 import {
     news,
     opinion,
@@ -6,6 +5,8 @@ import {
     culture,
     lifestyle,
 } from '@guardian/src-foundations/palette';
+
+import { Pillar } from '../types';
 
 type colour = string;
 
@@ -23,4 +24,5 @@ export const pillarPalette: Record<Pillar, PillarColours> = {
     [Pillar.Sport]: sport,
     [Pillar.Culture]: culture,
     [Pillar.Lifestyle]: lifestyle,
+    [Pillar.Labs]: lifestyle, // TODO: Get editorial palette from Source
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,11 @@
-import { Pillar } from '@guardian/types/Format';
+export const enum Pillar {
+    News = 0,
+    Opinion = 1,
+    Sport = 2,
+    Culture = 3,
+    Lifestyle = 4,
+    Labs = 5,
+}
 
 export type AdTargeting = {
     adUnit: string;


### PR DESCRIPTION
## What does this change?
Replaces the `Pillar` value from @guardian/types with a locally defined one that is very similar but that includes `labs`

## Why?
Because DCR needs labs supported. There is [an open PR](https://github.com/guardian/types/pull/42) to add labs to the /types repo but I want this to be a discussion and so by creating this workaround we remove the dependency and allow the PR time to be discussed if needed.