### PR TITLE
Use Pillar from @guardian/types

### DIFF
--- a/src/AudioAtom.stories.tsx
+++ b/src/AudioAtom.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { css } from 'emotion';
 
-import { Pillar } from './types';
+import { Pillar } from '@guardian/types/Format';
 
 import { AudioAtom } from './AudioAtom';
 

--- a/src/AudioAtom.test.tsx
+++ b/src/AudioAtom.test.tsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect';
 import { render } from '@testing-library/react';
 import { screen, fireEvent } from '@testing-library/dom';
 
-import { Pillar } from './types';
+import { Pillar } from '@guardian/types/Format';
 
 import { AudioAtom } from './AudioAtom';
 

--- a/src/AudioAtom.tsx
+++ b/src/AudioAtom.tsx
@@ -4,9 +4,10 @@ import { css } from 'emotion';
 import { textSans, headline } from '@guardian/src-foundations/typography';
 import { palette } from '@guardian/src-foundations';
 import { focusHalo } from '@guardian/src-foundations/accessibility';
+import { Pillar } from '@guardian/types/Format';
 
 import { pillarPalette } from './lib/pillarPalette';
-import { AudioAtomType, Pillar } from './types';
+import { AudioAtomType } from './types';
 
 const wrapperStyles = css`
     width: 100%;

--- a/src/ProfileAtom.stories.tsx
+++ b/src/ProfileAtom.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Pillar } from './types';
+import { Pillar } from '@guardian/types/Format';
 import { ProfileAtom } from './ProfileAtom';
 
 export default {

--- a/src/ProfileAtom.test.tsx
+++ b/src/ProfileAtom.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { render, fireEvent, screen } from '@testing-library/react';
 
-import { Pillar } from './types';
+import { Pillar } from '@guardian/types/Format';
 import { ProfileAtom } from './ProfileAtom';
 
 describe('ProfileAtom', () => {

--- a/src/TimelineAtom.tsx
+++ b/src/TimelineAtom.tsx
@@ -3,8 +3,9 @@ import { css } from 'emotion';
 
 import { neutral, brandAlt, space, remSpace } from '@guardian/src-foundations';
 import { body } from '@guardian/src-foundations/typography';
+import { Pillar } from '@guardian/types/Format';
 
-import { TimelineEvent, TimelineAtomType, Pillar } from './types';
+import { TimelineEvent, TimelineAtomType } from './types';
 
 import { Container } from './expandableAtom/Container';
 import { Footer } from './expandableAtom/Footer';

--- a/src/expandableAtom/Body.tsx
+++ b/src/expandableAtom/Body.tsx
@@ -5,7 +5,7 @@ import { neutral } from '@guardian/src-foundations/palette';
 import { body, textSans } from '@guardian/src-foundations/typography';
 import { SvgInfo } from '@guardian/src-icons';
 
-import { Pillar } from '../types';
+import { Pillar } from '@guardian/types/Format';
 import { pillarPalette } from '../lib/pillarPalette';
 
 // .forceHeightAndWidth needed at the moment to override global image sizing

--- a/src/expandableAtom/Container.tsx
+++ b/src/expandableAtom/Container.tsx
@@ -3,7 +3,7 @@ import { css } from 'emotion';
 
 import { neutral, text } from '@guardian/src-foundations/palette';
 
-import { Pillar } from '../types';
+import { Pillar } from '@guardian/types/Format';
 import { Summary } from './Summary';
 
 const containerStyling = css`

--- a/src/expandableAtom/Footer.tsx
+++ b/src/expandableAtom/Footer.tsx
@@ -3,7 +3,7 @@ import { css, cx } from 'emotion';
 
 import { textSans } from '@guardian/src-foundations/typography';
 
-import { Pillar } from '../types';
+import { Pillar } from '@guardian/types/Format';
 import { pillarPalette } from '../lib/pillarPalette';
 
 /// LIKE/DISLIKE FEEDBACK FOOTER

--- a/src/expandableAtom/Summary.tsx
+++ b/src/expandableAtom/Summary.tsx
@@ -5,7 +5,7 @@ import { textSans, headline, body } from '@guardian/src-foundations/typography';
 import { neutral } from '@guardian/src-foundations/palette/';
 import { SvgMinus, SvgPlus } from '@guardian/src-icons';
 
-import { Pillar } from '../types';
+import { Pillar } from '@guardian/types/Format';
 import { pillarPalette } from '../lib/pillarPalette';
 
 /// SUMMARY ELEMENT

--- a/src/fixtures/guideAtom.tsx
+++ b/src/fixtures/guideAtom.tsx
@@ -1,4 +1,4 @@
-import { Pillar } from '../types';
+import { Pillar } from '@guardian/types/Format';
 
 export const defaultStoryExpanded = {
     id: 'a76d998e-d4b0-4d00-8afb-773eddb4064c',

--- a/src/fixtures/qandaAtom.tsx
+++ b/src/fixtures/qandaAtom.tsx
@@ -1,4 +1,4 @@
-import { Pillar } from '../types';
+import { Pillar } from '@guardian/types/Format';
 
 export const imageStoryExpanded = {
     id: '78014307-ca67-47dc-b524-d5f24f3dbcd8',

--- a/src/fixtures/timelineAtom.tsx
+++ b/src/fixtures/timelineAtom.tsx
@@ -1,4 +1,4 @@
-import { Pillar } from '../types';
+import { Pillar } from '@guardian/types/Format';
 
 const NewsEvents = [
     {

--- a/src/lib/pillarPalette.ts
+++ b/src/lib/pillarPalette.ts
@@ -5,8 +5,7 @@ import {
     culture,
     lifestyle,
 } from '@guardian/src-foundations/palette';
-
-import { Pillar } from '../types';
+import { Pillar } from '@guardian/types/Format';
 
 type colour = string;
 
@@ -24,5 +23,5 @@ export const pillarPalette: Record<Pillar, PillarColours> = {
     [Pillar.Sport]: sport,
     [Pillar.Culture]: culture,
     [Pillar.Lifestyle]: lifestyle,
-    [Pillar.Labs]: lifestyle, // TODO: Get editorial palette from Source
+    // [Pillar.Labs]: lifestyle, // TODO: Get editorial palette from Source
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,4 @@
-export const enum Pillar {
-    News = 0,
-    Opinion = 1,
-    Sport = 2,
-    Culture = 3,
-    Lifestyle = 4,
-    Labs = 5,
-}
+import { Pillar } from '@guardian/types/Format';
 
 export type AdTargeting = {
     adUnit: string;


### PR DESCRIPTION
## What does this change?
Replace the locally defined const enum Pillar with the import from @guardian/types

## Why?
We were using a local const enum as a tempoary measure ahead of using the main type from /types