### PR TITLE
Knowledge quiz submit per question

### DIFF
--- a/src/Answers.stories.tsx
+++ b/src/Answers.stories.tsx
@@ -23,24 +23,17 @@ export const Answers = (): JSX.Element => (
     >
         <CorrectSelectedAnswer
             id="someId3"
-            name="someName"
             answerText="Correct Selected Answer"
             explainerText="this is such a cool answer"
         />
         <NonSelectedCorrectAnswer
             id="someId4"
-            name="someName"
             answerText="Correct Non Selected Answer"
             explainerText="this is such a cool answer"
         />
-        <IncorrectAnswer
-            id="someId5"
-            name="someName"
-            answerText="Incorrect Answer"
-        />
+        <IncorrectAnswer id="someId5" answerText="Incorrect Answer" />
         <UnselectedAnswer
             id="someId1"
-            name="someName"
             answerText="Unselectable unanswered answer"
         />
         <div className={radioButtonWrapperStyles}>

--- a/src/Answers.tsx
+++ b/src/Answers.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import { css, cx } from 'emotion';
+import { css } from 'emotion';
 
 import { SvgCheckmark, SvgCross } from '@guardian/src-icons';
 import { neutral, news, success } from '@guardian/src-foundations/palette';
 import { body, textSans } from '@guardian/src-foundations/typography';
-import { visuallyHidden } from '@guardian/src-foundations/accessibility';
 import { space } from '@guardian/src-foundations';
 
 // We export Radio wrapper styles to override Source Radio buttons to align
@@ -35,16 +34,14 @@ const AnswerWithSVG = ({
     id,
     text,
     supplementText,
-    name,
     isCorrect,
-    answertype,
+    answerType,
 }: {
     id: string;
     text: string;
     supplementText?: string;
-    name: string;
     isCorrect: boolean;
-    answertype: string;
+    answerType: string;
 }): JSX.Element => (
     <div
         className={css`
@@ -75,20 +72,6 @@ const AnswerWithSVG = ({
         >
             {isCorrect ? <SvgCheckmark /> : <SvgCross />}
         </div>
-        <input
-            type="radio"
-            id={id}
-            name={name}
-            data-testid={id}
-            className={cx(
-                css`
-                    ${visuallyHidden}
-                `,
-            )}
-            data-answertype={answertype}
-            required
-            tabIndex={-1}
-        />
         <label
             className={css`
                 color: ${neutral[100]};
@@ -97,6 +80,8 @@ const AnswerWithSVG = ({
 
                 ${body.medium()};
             `}
+            id={id}
+            data-answer-type={answerType}
         >
             <span
                 className={css`
@@ -122,18 +107,14 @@ const AnswerWithoutSVG = ({
     id,
     text,
     supplementText,
-    name,
     isCorrect,
-    answertype,
-    hasBeenAnswered,
+    answerType,
 }: {
     id: string;
     text: string;
     supplementText?: string;
-    name: string;
     isCorrect?: boolean;
-    answertype: string;
-    hasBeenAnswered: boolean;
+    answerType: string;
 }): JSX.Element => (
     <div
         className={css`
@@ -151,26 +132,14 @@ const AnswerWithoutSVG = ({
             padding-left: ${space[9]}px;
         `}
     >
-        <input
-            type="radio"
-            id={id}
-            name={name}
-            data-testid={id}
-            className={cx(
-                css`
-                    ${visuallyHidden}
-                `,
-            )}
-            data-answertype={answertype}
-            required
-            tabIndex={hasBeenAnswered ? -1 : 0}
-        />
         <label
             className={css`
                 margin-left: ${space[1]}px;
                 display: flex;
                 flex-direction: column;
             `}
+            id={id}
+            data-answer-type={answerType}
         >
             <span
                 className={css`
@@ -196,39 +165,32 @@ export const CorrectSelectedAnswer = ({
     answerText,
     explainerText,
     id,
-    name,
 }: {
     answerText: string;
     explainerText: string;
     id: string;
-    name: string;
 }): JSX.Element => (
     <AnswerWithoutSVG
         id={id}
-        name={name}
         text={answerText}
         supplementText={explainerText}
         isCorrect={true}
-        answertype="correct-selected-answer"
-        hasBeenAnswered={true}
+        answerType="correct-selected-answer"
     />
 );
 
 export const IncorrectAnswer = ({
     answerText,
     id,
-    name,
 }: {
     answerText: string;
     id: string;
-    name: string;
 }): JSX.Element => (
     <AnswerWithSVG
         id={id}
-        name={name}
         text={answerText}
         isCorrect={false}
-        answertype="incorrect-answer"
+        answerType="incorrect-answer"
     />
 );
 
@@ -236,37 +198,30 @@ export const NonSelectedCorrectAnswer = ({
     answerText,
     explainerText,
     id,
-    name,
 }: {
     answerText: string;
     explainerText: string;
     id: string;
-    name: string;
 }): JSX.Element => (
     <AnswerWithSVG
         id={id}
-        name={name}
         text={answerText}
         supplementText={explainerText}
         isCorrect={true}
-        answertype="non-selected-correct-answer"
+        answerType="non-selected-correct-answer"
     />
 );
 
 export const UnselectedAnswer = ({
-    answerText,
     id,
-    name,
+    answerText,
 }: {
     answerText: string;
     id: string;
-    name: string;
 }): JSX.Element => (
     <AnswerWithoutSVG
         id={id}
-        name={name}
         text={answerText}
-        answertype="unselected-disabled-answer"
-        hasBeenAnswered={false}
+        answerType="unselected-disabled-answer"
     />
 );

--- a/src/Answers.tsx
+++ b/src/Answers.tsx
@@ -80,7 +80,7 @@ const AnswerWithSVG = ({
 
                 ${body.medium()};
             `}
-            id={id}
+            data-testid={id}
             data-answer-type={answerType}
         >
             <span
@@ -138,7 +138,7 @@ const AnswerWithoutSVG = ({
                 display: flex;
                 flex-direction: column;
             `}
-            id={id}
+            data-testid={id}
             data-answer-type={answerType}
         >
             <span

--- a/src/KnowledgeQuiz.test.tsx
+++ b/src/KnowledgeQuiz.test.tsx
@@ -16,6 +16,7 @@ describe('KnowledgeQuiz', () => {
         expect(getByText(questions[0].text)).toBeInTheDocument();
     });
     describe('on answer click', () => {
+        const questionId = 'b0342160-7678-417d-85c6-67a60ec4994b';
         const correctAnswer = {
             id: 'c5c49561-d9df-4fd4-a7bb-47e7e0a88240',
             text: 'Dino Zoff',
@@ -47,7 +48,7 @@ describe('KnowledgeQuiz', () => {
             rerender(<KnowledgeQuizAtom id="123abc" questions={questions} />);
 
             expect(
-                getByTestId(correctAnswer.id).getAttribute('data-answertype'),
+                getByTestId(correctAnswer.id).getAttribute('data-answer-type'),
             ).toBe('selected-enabled-answer');
         });
 
@@ -57,11 +58,11 @@ describe('KnowledgeQuiz', () => {
             );
 
             fireEvent.click(getByTestId(correctAnswer.id));
-            fireEvent.click(getByTestId('submit-quiz'));
+            fireEvent.click(getByTestId(`submit-question-${questionId}`));
             rerender(<KnowledgeQuizAtom id="123abc" questions={questions} />);
 
             expect(
-                getByTestId(correctAnswer.id).getAttribute('data-answertype'),
+                getByTestId(correctAnswer.id).getAttribute('data-answer-type'),
             ).toBe('correct-selected-answer');
         });
 
@@ -71,14 +72,16 @@ describe('KnowledgeQuiz', () => {
             );
 
             fireEvent.click(getByTestId(incorrectAnswer.id));
-            fireEvent.click(getByTestId('submit-quiz'));
+            fireEvent.click(getByTestId(`submit-question-${questionId}`));
             rerender(<KnowledgeQuizAtom id="123abc" questions={questions} />);
 
             expect(
-                getByTestId(incorrectAnswer.id).getAttribute('data-answertype'),
+                getByTestId(incorrectAnswer.id).getAttribute(
+                    'data-answer-type',
+                ),
             ).toBe('incorrect-answer');
             expect(
-                getByTestId(correctAnswer.id).getAttribute('data-answertype'),
+                getByTestId(correctAnswer.id).getAttribute('data-answer-type'),
             ).toBe('non-selected-correct-answer');
         });
 
@@ -89,17 +92,17 @@ describe('KnowledgeQuiz', () => {
 
             expect(
                 getByTestId(incorrectUnselectedAnswer.id).getAttribute(
-                    'data-answertype',
+                    'data-answer-type',
                 ),
             ).toBe('unselected-enabled-answer');
 
             fireEvent.click(getByTestId(correctAnswer.id));
-            fireEvent.click(getByTestId('submit-quiz'));
+            fireEvent.click(getByTestId(`submit-question-${questionId}`));
             rerender(<KnowledgeQuizAtom id="123abc" questions={questions} />);
 
             expect(
                 getByTestId(incorrectUnselectedAnswer.id).getAttribute(
-                    'data-answertype',
+                    'data-answer-type',
                 ),
             ).toBe('unselected-disabled-answer');
         });

--- a/src/KnowledgeQuiz.tsx
+++ b/src/KnowledgeQuiz.tsx
@@ -248,7 +248,7 @@ const Answers = ({
                         key={answer.id}
                         value={answer.text}
                         data-testid={answer.id}
-                        data-answertype={
+                        data-answer-type={
                             selectedAnswer === answer.id
                                 ? 'selected-enabled-answer'
                                 : 'unselected-enabled-answer'

--- a/src/KnowledgeQuiz.tsx
+++ b/src/KnowledgeQuiz.tsx
@@ -90,7 +90,7 @@ export const Question = ({
                                 padding-right: 12px;
                             `}
                         >
-                            {number + '.'}
+                            {`${number}.`}
                         </span>
                         {text}
                     </legend>

--- a/src/KnowledgeQuiz.tsx
+++ b/src/KnowledgeQuiz.tsx
@@ -148,27 +148,6 @@ export const Question = ({
                     >
                         Submit
                     </Button>
-                    <Button
-                        priority="secondary"
-                        data-testid={`reset-question-${id}`}
-                        onClick={() => {
-                            setHasSubmitted(false);
-                            setSelectedAnswer('');
-                        }}
-                        onKeyDown={(e) => {
-                            const spaceKey = 32;
-                            const enterKey = 13;
-                            if (
-                                e.keyCode === spaceKey ||
-                                e.keyCode === enterKey
-                            ) {
-                                setHasSubmitted(false);
-                                setSelectedAnswer('');
-                            }
-                        }}
-                    >
-                        Reset
-                    </Button>
                 </div>
             </fieldset>
         </div>

--- a/src/KnowledgeQuiz.tsx
+++ b/src/KnowledgeQuiz.tsx
@@ -120,6 +120,7 @@ export const Question = ({
                     `}
                 >
                     <Button
+                        size="small"
                         data-testid={`submit-question-${id}`}
                         onClick={() => {
                             setHasSubmitted(true);

--- a/src/KnowledgeQuiz.tsx
+++ b/src/KnowledgeQuiz.tsx
@@ -103,20 +103,13 @@ export const Question = ({
                         src={imageUrl}
                     />
                 )}
-                <div
-                    className={css`
-                        /* fix for chrome jumping to top of page */
-                        position: relative;
-                    `}
-                >
-                    <Answers
-                        id={id}
-                        answers={answers}
-                        hasSubmitted={hasSubmitted}
-                        selectedAnswer={selectedAnswer}
-                        updateSelectedAnswer={updateSelectedAnswer}
-                    />
-                </div>
+                <Answers
+                    id={id}
+                    answers={answers}
+                    hasSubmitted={hasSubmitted}
+                    selectedAnswer={selectedAnswer}
+                    updateSelectedAnswer={updateSelectedAnswer}
+                />
                 <div
                     className={css`
                         display: flex;

--- a/src/KnowledgeQuiz.tsx
+++ b/src/KnowledgeQuiz.tsx
@@ -42,80 +42,20 @@ const fieldsetStyle = css`
 export const KnowledgeQuizAtom = ({
     id,
     questions,
-}: QuizAtomType): JSX.Element => {
-    const [selectedAnswers, setSelectedAnswers] = useState<{
-        [key: string]: string;
-    }>({});
-
-    const [hasSubmittedAnswers, setHasSubmittedAnswers] = useState<boolean>(
-        false,
-    );
-    return (
-        <Fragment>
-            <form data-atom-id={id}>
-                {questions.map((question, idx) => (
-                    <Question
-                        key={question.id}
-                        id={question.id}
-                        number={idx + 1}
-                        text={question.text}
-                        imageUrl={question.imageUrl}
-                        answers={question.answers}
-                        hasSubmittedAnswers={hasSubmittedAnswers}
-                        selectedAnswers={selectedAnswers}
-                        updateSelectedAnswer={(selectedAnswerId: string) => {
-                            setSelectedAnswers({
-                                ...selectedAnswers,
-                                [question.id]: selectedAnswerId,
-                            });
-                        }}
-                    />
-                ))}
-            </form>
-            <div
-                className={css`
-                    display: flex;
-                    flex-direction: row;
-                    button {
-                        margin-right: 10px;
-                    }
-                `}
-            >
-                <Button
-                    type="submit"
-                    onClick={() => setHasSubmittedAnswers(true)}
-                    onKeyDown={(e) => {
-                        const spaceKey = 32;
-                        const enterKey = 13;
-                        if (e.keyCode === spaceKey || e.keyCode === enterKey)
-                            setHasSubmittedAnswers(true);
-                    }}
-                    data-testid="submit-quiz"
-                >
-                    Submit
-                </Button>
-                <Button
-                    priority="secondary"
-                    onClick={() => {
-                        setHasSubmittedAnswers(false);
-                        setSelectedAnswers({});
-                    }}
-                    onKeyDown={(e) => {
-                        const spaceKey = 32;
-                        const enterKey = 13;
-                        if (e.keyCode === spaceKey || e.keyCode === enterKey) {
-                            setHasSubmittedAnswers(false);
-                            setSelectedAnswers({});
-                        }
-                    }}
-                    data-testid="reset-quiz"
-                >
-                    Reset
-                </Button>
-            </div>
-        </Fragment>
-    );
-};
+}: QuizAtomType): JSX.Element => (
+    <form data-atom-id={id}>
+        {questions.map((question, idx) => (
+            <Question
+                key={question.id}
+                id={question.id}
+                number={idx + 1}
+                text={question.text}
+                imageUrl={question.imageUrl}
+                answers={question.answers}
+            />
+        ))}
+    </form>
+);
 
 export const Question = ({
     id,
@@ -123,86 +63,136 @@ export const Question = ({
     imageUrl,
     answers,
     number,
-    hasSubmittedAnswers,
-    selectedAnswers,
-    updateSelectedAnswer,
 }: QuestionType & {
     number: number;
-    hasSubmittedAnswers: boolean;
-    selectedAnswers: {
-        [key: string]: string;
-    };
-    updateSelectedAnswer: (selectedAnswerId: string) => void;
-}): JSX.Element => (
-    <div
-        className={css`
-            ${body.medium()};
-        `}
-    >
-        <fieldset className={fieldsetStyle}>
-            <div>
-                <legend
-                    className={css`
-                        margin-bottom: 12px;
-                    `}
-                >
-                    <span
+}): JSX.Element => {
+    const [selectedAnswer, setSelectedAnswer] = useState<string>('');
+    const [hasSubmitted, setHasSubmitted] = useState<boolean>(false);
+
+    const updateSelectedAnswer = (selectedAnswerId: string) =>
+        setSelectedAnswer(selectedAnswerId);
+
+    return (
+        <div
+            className={css`
+                ${body.medium()};
+            `}
+        >
+            <fieldset className={fieldsetStyle}>
+                <div>
+                    <legend
                         className={css`
-                            padding-right: 12px;
+                            margin-bottom: 12px;
                         `}
                     >
-                        {number + '.'}
-                    </span>
-                    {text}
-                </legend>
-            </div>
-            {imageUrl && (
-                <img
+                        <span
+                            className={css`
+                                padding-right: 12px;
+                            `}
+                        >
+                            {number + '.'}
+                        </span>
+                        {text}
+                    </legend>
+                </div>
+                {imageUrl && (
+                    <img
+                        className={css`
+                            width: 100%;
+                        `}
+                        src={imageUrl}
+                    />
+                )}
+                <div
                     className={css`
-                        width: 100%;
+                        /* fix for chrome jumping to top of page */
+                        position: relative;
                     `}
-                    src={imageUrl}
-                />
-            )}
-            <div
-                className={css`
-                    /* fix for chrome jumping to top of page */
-                    position: relative;
-                `}
-            >
-                <Answers
-                    id={id}
-                    answers={answers}
-                    hasSubmittedAnswers={hasSubmittedAnswers}
-                    selectedAnswers={selectedAnswers}
-                    updateSelectedAnswer={updateSelectedAnswer}
-                />
-            </div>
-        </fieldset>
-    </div>
-);
+                >
+                    <Answers
+                        id={id}
+                        answers={answers}
+                        hasSubmitted={hasSubmitted}
+                        selectedAnswer={selectedAnswer}
+                        updateSelectedAnswer={updateSelectedAnswer}
+                    />
+                </div>
+                <div
+                    className={css`
+                        display: flex;
+                        flex-direction: row;
+                        button {
+                            margin-right: 10px;
+                        }
+                    `}
+                >
+                    <Button
+                        type="submit"
+                        data-testid={`submit-question-${id}`}
+                        onClick={(e) => {
+                            e.preventDefault();
+                            setHasSubmitted(true);
+                        }}
+                        onKeyDown={(e) => {
+                            const spaceKey = 32;
+                            const enterKey = 13;
+                            if (
+                                e.keyCode === spaceKey ||
+                                e.keyCode === enterKey
+                            ) {
+                                // prevent submit
+                                e.preventDefault();
+                                setHasSubmitted(true);
+                            }
+                        }}
+                    >
+                        Submit
+                    </Button>
+                    <Button
+                        priority="secondary"
+                        data-testid={`reset-question-${id}`}
+                        onClick={() => {
+                            setHasSubmitted(false);
+                            setSelectedAnswer('');
+                        }}
+                        onKeyDown={(e) => {
+                            const spaceKey = 32;
+                            const enterKey = 13;
+                            if (
+                                e.keyCode === spaceKey ||
+                                e.keyCode === enterKey
+                            ) {
+                                setHasSubmitted(false);
+                                setSelectedAnswer('');
+                            }
+                        }}
+                    >
+                        Reset
+                    </Button>
+                </div>
+            </fieldset>
+        </div>
+    );
+};
 
 const Answers = ({
     answers,
     id: questionId,
-    hasSubmittedAnswers,
-    selectedAnswers,
+    hasSubmitted,
+    selectedAnswer,
     updateSelectedAnswer,
 }: {
     answers: AnswerType[];
     id: string;
-    hasSubmittedAnswers: boolean;
-    selectedAnswers: {
-        [key: string]: string;
-    };
+    hasSubmitted: boolean;
+    selectedAnswer?: string;
     updateSelectedAnswer: (selectedAnswerId: string) => void;
 }) => {
-    if (hasSubmittedAnswers) {
+    if (hasSubmitted) {
         return (
             <Fragment>
                 {answers.map((answer) => {
-                    const isSelected =
-                        selectedAnswers[questionId] === answer.id;
+                    const isSelected = selectedAnswer === answer.id;
 
                     if (isSelected) {
                         if (answer.isCorrect) {
@@ -210,7 +200,6 @@ const Answers = ({
                                 <CorrectSelectedAnswer
                                     key={answer.id}
                                     id={answer.id}
-                                    name={questionId}
                                     answerText={answer.text}
                                     explainerText={answer.revealText || ''}
                                 />
@@ -222,7 +211,6 @@ const Answers = ({
                                 <IncorrectAnswer
                                     key={answer.id}
                                     id={answer.id}
-                                    name={questionId}
                                     answerText={answer.text}
                                 />
                             );
@@ -233,7 +221,6 @@ const Answers = ({
                         return (
                             <NonSelectedCorrectAnswer
                                 key={answer.id}
-                                name={questionId}
                                 id={answer.id}
                                 answerText={answer.text}
                                 explainerText={answer.revealText || ''}
@@ -243,7 +230,6 @@ const Answers = ({
 
                     return (
                         <UnselectedAnswer
-                            name={questionId}
                             key={answer.id}
                             id={answer.id}
                             answerText={answer.text}
@@ -263,14 +249,14 @@ const Answers = ({
                         value={answer.text}
                         data-testid={answer.id}
                         data-answertype={
-                            selectedAnswers[questionId] === answer.id
+                            selectedAnswer === answer.id
                                 ? 'selected-enabled-answer'
                                 : 'unselected-enabled-answer'
                         }
                         name={questionId}
                         label={answer.text}
                         onChange={() => updateSelectedAnswer(answer.id)}
-                        checked={selectedAnswers[questionId] === answer.id}
+                        checked={selectedAnswer === answer.id}
                     />
                 ))}
             </RadioGroup>

--- a/src/KnowledgeQuiz.tsx
+++ b/src/KnowledgeQuiz.tsx
@@ -120,10 +120,8 @@ export const Question = ({
                     `}
                 >
                     <Button
-                        type="submit"
                         data-testid={`submit-question-${id}`}
-                        onClick={(e) => {
-                            e.preventDefault();
+                        onClick={() => {
                             setHasSubmitted(true);
                         }}
                         onKeyDown={(e) => {
@@ -133,13 +131,11 @@ export const Question = ({
                                 e.keyCode === spaceKey ||
                                 e.keyCode === enterKey
                             ) {
-                                // prevent submit
-                                e.preventDefault();
                                 setHasSubmitted(true);
                             }
                         }}
                     >
-                        Submit
+                        Reveal
                     </Button>
                 </div>
             </fieldset>

--- a/src/KnowledgeQuiz.tsx
+++ b/src/KnowledgeQuiz.tsx
@@ -66,7 +66,7 @@ export const Question = ({
 }: QuestionType & {
     number: number;
 }): JSX.Element => {
-    const [selectedAnswer, setSelectedAnswer] = useState<string>('');
+    const [selectedAnswer, setSelectedAnswer] = useState<string | undefined>();
     const [hasSubmitted, setHasSubmitted] = useState<boolean>(false);
 
     const updateSelectedAnswer = (selectedAnswerId: string) =>

--- a/src/PersonalityQuiz.test.tsx
+++ b/src/PersonalityQuiz.test.tsx
@@ -47,7 +47,7 @@ describe('PersonalityQuiz', () => {
             );
 
             expect(
-                getByTestId(selectedAnswer.id).getAttribute('data-answertype'),
+                getByTestId(selectedAnswer.id).getAttribute('data-answer-type'),
             ).toBe('selected-enabled-answer');
         });
 

--- a/src/PersonalityQuiz.tsx
+++ b/src/PersonalityQuiz.tsx
@@ -317,7 +317,7 @@ const PersonalityQuizAnswers = ({
                         value={answer.text}
                         label={answer.text}
                         data-testid={answer.id}
-                        data-answertype={
+                        data-answer-type={
                             selectedAnswer === answer.id
                                 ? 'selected-enabled-answer'
                                 : 'unselected-enabled-answer'


### PR DESCRIPTION
## What does this change?
We add a `submit` and `reset` button per question on the knowledge quiz

## Why?

We use to instantly display correct and incorrect answers once an option was selected, but this was found to not work for keyboard users. Instead we went with the idea of having a submit button at the end of the quiz that would change the state of the quiz to display correct/incorrect answers based on selection.  

But that current implementation means that we display correct answers for questions we may not have answered, plus in terms of UX its not great as you would have to scroll back up and down to see what you got right and wrong.  

This is a compramise that keeps accessibility while maintaining some level of UX by not requiring up and down scrolls.

## How to test
Check out the story, use keyboard and mouse to make sure you can submit both ways

## Images
<img width="1369" alt="Screenshot 2021-01-07 at 15 24 43" src="https://user-images.githubusercontent.com/8831403/103910519-d3c7cf00-50fc-11eb-8307-e3d06c29d882.png">
