### PR TITLE
Replace Youtube overlay colours with decide palette

### DIFF
--- a/src/YoutubeAtom.stories.tsx
+++ b/src/YoutubeAtom.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { YoutubeAtom } from './YoutubeAtom';
+import { Pillar } from '@guardian/types/Format';
 import { sport } from '@guardian/src-foundations';
 
 export default {
@@ -25,7 +26,7 @@ export const DefaultStory = (): JSX.Element => {
                     (e) => console.log(`analytics event ${e} called`),
                 ]}
                 duration={252}
-                pillar={2} // Sport
+                pillar={Pillar.Culture}
             />
         </div>
     );
@@ -47,7 +48,7 @@ export const WithOverrideImage = (): JSX.Element => {
                     (e) => console.log(`analytics event ${e} called`),
                 ]}
                 duration={252}
-                pillar={0} // News
+                pillar={Pillar.News}
                 overrideImage={[
                     {
                         srcSet: [
@@ -79,7 +80,7 @@ export const WithPosterImage = (): JSX.Element => {
                 eventEmitters={[
                     (e) => console.log(`analytics event ${e} called`),
                 ]}
-                pillar={2}
+                pillar={Pillar.Sport}
                 duration={252}
                 posterImage={[
                     {
@@ -128,7 +129,7 @@ export const WithOverlayAndPosterImage = (): JSX.Element => {
                     (e) => console.log(`analytics event ${e} called`),
                 ]}
                 duration={252}
-                pillar={0}
+                pillar={Pillar.Opinion}
                 overrideImage={[
                     {
                         srcSet: [

--- a/src/YoutubeAtom.stories.tsx
+++ b/src/YoutubeAtom.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { css } from 'emotion';
 
 import { YoutubeAtom } from './YoutubeAtom';
+import { sport } from '@guardian/src-foundations';
 
 export default {
     title: 'YoutubeAtom',
@@ -24,6 +25,7 @@ export const DefaultStory = (): JSX.Element => {
                     (e) => console.log(`analytics event ${e} called`),
                 ]}
                 duration={252}
+                pillar={2} // Sport
             />
         </div>
     );
@@ -45,6 +47,7 @@ export const WithOverrideImage = (): JSX.Element => {
                     (e) => console.log(`analytics event ${e} called`),
                 ]}
                 duration={252}
+                pillar={0} // News
                 overrideImage={[
                     {
                         srcSet: [
@@ -76,6 +79,7 @@ export const WithPosterImage = (): JSX.Element => {
                 eventEmitters={[
                     (e) => console.log(`analytics event ${e} called`),
                 ]}
+                pillar={2}
                 duration={252}
                 posterImage={[
                     {
@@ -124,6 +128,7 @@ export const WithOverlayAndPosterImage = (): JSX.Element => {
                     (e) => console.log(`analytics event ${e} called`),
                 ]}
                 duration={252}
+                pillar={0}
                 overrideImage={[
                     {
                         srcSet: [

--- a/src/YoutubeAtom.test.tsx
+++ b/src/YoutubeAtom.test.tsx
@@ -13,12 +13,17 @@ describe('YoutubeAtom', () => {
                 alt=""
                 role="inline"
                 eventEmitters={[]}
+                pillar={0}
             />
         );
         const { getByTitle } = render(atom);
 
         expect(getByTitle('My Youtube video!')).toBeInTheDocument();
-        expect(getByTitle('My Youtube video!'))
-            .toHaveAttribute('src', expect.stringMatching(/https:\/\/www.youtube-nocookie.com\/embed.*/))
+        expect(getByTitle('My Youtube video!')).toHaveAttribute(
+            'src',
+            expect.stringMatching(
+                /https:\/\/www.youtube-nocookie.com\/embed.*/,
+            ),
+        );
     });
 });

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { css, cx } from 'emotion';
 import YouTubePlayer from 'youtube-player';
+import { pillarPalette } from './lib/pillarPalette';
 
 import { focusHalo } from '@guardian/src-foundations/accessibility';
 import { palette, space } from '@guardian/src-foundations';
@@ -11,6 +12,7 @@ import { MaintainAspectRatio } from './common/MaintainAspectRatio';
 import { formatTime } from './lib/formatTime';
 import { Picture } from './Picture';
 import { ImageSource, RoleType } from './types';
+import { Pillar } from '@guardian/types/Format';
 
 type Props = {
     assetId: string;
@@ -25,6 +27,7 @@ type Props = {
     duration?: number; // in seconds
     origin?: string;
     eventEmitters: ((event: VideoEventKey) => void)[];
+    pillar: Pillar;
 };
 declare global {
     interface Window {
@@ -120,8 +123,8 @@ const hideOverlayStyling = css`
     transition-duration: 500ms;
 `;
 
-const playButtonStyling = css`
-    background-color: ${palette['news'][500]};
+const playButtonStyling = (pillar: Pillar) => css`
+    background-color: ${pillarPalette[pillar][500]};
     border-radius: 100%;
     height: 60px;
     width: 60px;
@@ -148,10 +151,10 @@ const overlayInfoWrapperStyles = css`
     left: ${space[4]}px;
 `;
 
-const videoDurationStyles = css`
+const videoDurationStyles = (pillar: Pillar) => css`
     ${textSans.medium({ fontWeight: 'bold' })};
     padding-left: ${space[3]}px;
-    color: ${palette['news'][500]};
+    color: ${pillarPalette[pillar][500]};
 `;
 
 type YoutubeCallback = (
@@ -183,6 +186,7 @@ export const YoutubeAtom = ({
     duration,
     origin,
     eventEmitters,
+    pillar,
 }: Props): JSX.Element => {
     const embedConfig =
         adTargeting && JSON.stringify(buildEmbedConfig(adTargeting));
@@ -322,12 +326,14 @@ export const YoutubeAtom = ({
                     />
                     <div className={overlayInfoWrapperStyles}>
                         <div
-                            className={`${playButtonStyling} overlay-play-button`}
+                            className={`${playButtonStyling(
+                                pillar,
+                            )} overlay-play-button`}
                         >
                             <SvgPlay />
                         </div>
                         {duration && (
-                            <div className={videoDurationStyles}>
+                            <div className={videoDurationStyles(pillar)}>
                                 {formatTime(duration)}
                             </div>
                         )}


### PR DESCRIPTION
## What does this change?
The Youtube overlay play buttons and duration now use decidePalette to choose the correct colour based on the pillar.

## Images
![Screenshot 2021-01-07 at 14 29 17](https://user-images.githubusercontent.com/35331926/103904525-4af96500-50f5-11eb-8c49-5c0bd3ba5377.png)
![Screenshot 2021-01-07 at 14 29 23](https://user-images.githubusercontent.com/35331926/103904538-4fbe1900-50f5-11eb-8ee5-b600aec65e99.png)
