### PR TITLE
Remove Origin URL when running development

### DIFF
--- a/src/YoutubeAtom.stories.tsx
+++ b/src/YoutubeAtom.stories.tsx
@@ -3,7 +3,6 @@ import { css } from 'emotion';
 
 import { YoutubeAtom } from './YoutubeAtom';
 import { Pillar } from '@guardian/types/Format';
-import { sport } from '@guardian/src-foundations';
 
 export default {
     title: 'YoutubeAtom',
@@ -27,6 +26,7 @@ export const DefaultStory = (): JSX.Element => {
                 ]}
                 duration={252}
                 pillar={Pillar.Culture}
+                origin="https://www.theguardian.com"
             />
         </div>
     );
@@ -60,6 +60,7 @@ export const WithOverrideImage = (): JSX.Element => {
                         ],
                     },
                 ]}
+                origin="https://www.theguardian.com"
             />
         </div>
     );
@@ -108,6 +109,7 @@ export const WithPosterImage = (): JSX.Element => {
                         ],
                     },
                 ]}
+                origin="https://www.theguardian.com"
             />
         </div>
     );
@@ -167,6 +169,7 @@ export const WithOverlayAndPosterImage = (): JSX.Element => {
                         ],
                     },
                 ]}
+                origin="https://www.theguardian.com"
             />
         </div>
     );

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -190,7 +190,10 @@ export const YoutubeAtom = ({
 }: Props): JSX.Element => {
     const embedConfig =
         adTargeting && JSON.stringify(buildEmbedConfig(adTargeting));
-    const originString = origin ? `&origin=${origin}` : '';
+    const originString =
+        origin && process.env.NODE_ENV !== 'development'
+            ? `&origin=${origin}`
+            : '';
     const iframeSrc = `https://www.youtube-nocookie.com/embed/${assetId}?embed_config=${embedConfig}&enablejsapi=1${originString}&widgetid=1&modestbranding=1`;
 
     const [hasUserLaunchedPlay, setHasUserLaunchedPlay] = useState<boolean>(


### PR DESCRIPTION
## What does this change?
Use `process.env.NODE_ENV` to detemin if running in Production. Make sure that origin is not set in development enviroments
