### PR TITLE
Remove rootDir

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
         "jsx": "react",
         "moduleResolution": "node",
         "allowJs": true,
-        "rootDir": ".",
         "skipLibCheck": true,
         "allowSyntheticDefaultImports": true,
         "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## What does this change?
Removes the [rootDir compiler option](https://www.typescriptlang.org/tsconfig#rootDir) so that Typescript decides which directory itself

## Why?
This prevents the `/src` dir becoming part of the structure which causes discovery problems whem importing this lib elsewhere