### PR TITLE
Reverting  changes to use the youtube-nocookie.com in youtube atom

### DIFF
--- a/src/YoutubeAtom.test.tsx
+++ b/src/YoutubeAtom.test.tsx
@@ -22,7 +22,7 @@ describe('YoutubeAtom', () => {
         expect(getByTitle('My Youtube video!')).toHaveAttribute(
             'src',
             expect.stringMatching(
-                /https:\/\/www.youtube-nocookie.com\/embed.*/,
+                /https:\/\/www.youtube.com\/embed.*/,
             ),
         );
     });

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -191,7 +191,7 @@ export const YoutubeAtom = ({
     const embedConfig =
         adTargeting && JSON.stringify(buildEmbedConfig(adTargeting));
     const originString = origin ? `&origin=${origin}` : '';
-    const iframeSrc = `https://www.youtube-nocookie.com/embed/${assetId}?embed_config=${embedConfig}&enablejsapi=1${originString}&widgetid=1&modestbranding=1`;
+    const iframeSrc = `https://www.youtube.com/embed/${assetId}?embed_config=${embedConfig}&enablejsapi=1${originString}&widgetid=1&modestbranding=1`;
 
     const [hasUserLaunchedPlay, setHasUserLaunchedPlay] = useState<boolean>(
         false,


### PR DESCRIPTION
## What does this change?
This reverts the changes introduced to enable enhanced privacy mode for youtube atoms. This change would have had implications for advertising revenue for guardian videos hosted on youtube. 

The other youtube components on the site will continue to use the youtube-nocookie.com

This is consistent with the current implementation for details see:

https://github.com/guardian/frontend/pull/21747

## How can we measure success?
There should be no drop in revenue when live blogs and video pages are served by DCR

