### PR TITLE
Make youtube-player as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,8 +73,7 @@
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "ts-jest": "^24.3.0",
-        "ts-loader": "^8.0.14",
-        "youtube-player": "^5.5.2"
+        "ts-loader": "^8.0.14"
     },
     "eslintConfig": {
         "root": true,
@@ -112,8 +111,7 @@
         "preact": "^10.5.7",
         "preact-render-to-string": "^5.1.12",
         "react": "^16.14.0",
-        "react-dom": "^16.14.0",
-        "youtube-player": "^5.5.2"
+        "react-dom": "^16.14.0"
     },
     "jest": {
         "testEnvironment": "jest-environment-jsdom-sixteen",
@@ -144,5 +142,8 @@
         "collectCoverageFrom": [
             "src/**/*.{ts,tsx}"
         ]
+    },
+    "dependencies": {
+        "youtube-player": "^5.5.2"
     }
 }


### PR DESCRIPTION
## What does this change?
Remove `youtube-player` as a peer dependency and instead make it a dependency.

## Why?
We do not use `youtube-player` in DCR. It makes sense for it to be bundled as part of atoms rendering
