### PR TITLE
Youtube support fullscreen

### DIFF
--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -299,6 +299,7 @@ export const YoutubeAtom = ({
                 // https://stackoverflow.com/a/53298579/7378674
                 allow="autoplay"
                 tabIndex={overrideImage || posterImage ? -1 : 0}
+                allowFullScreen
             />
 
             {(overrideImage || posterImage) && (


### PR DESCRIPTION
## What does this change?

Allow fullscreen support for youtube atoms videos

## Images

### Before
<img width="146" alt="Screenshot 2021-01-25 at 11 10 48" src="https://user-images.githubusercontent.com/8831403/105698666-1ca1c500-5efe-11eb-8c53-48ce75e77d43.png">

### After
<img width="152" alt="Screenshot 2021-01-25 at 11 10 43" src="https://user-images.githubusercontent.com/8831403/105698680-20cde280-5efe-11eb-8c2d-658134ae1634.png">

