### PR TITLE
Remove forceHeightAndWidth as className

### DIFF
--- a/src/expandableAtom/Body.tsx
+++ b/src/expandableAtom/Body.tsx
@@ -8,13 +8,7 @@ import { SvgInfo } from '@guardian/src-icons';
 import { Theme } from '@guardian/types';
 import { pillarPalette } from '../lib/pillarPalette';
 
-// .forceHeightAndWidth needed at the moment to override global image sizing
-// which forces images to 100%
 const imageStyling = css`
-    .forceHeightAndWidth & {
-        width: 100px;
-        height: 100px;
-    }
     float: left;
     margin-right: 16px;
     margin-bottom: 6px;
@@ -22,6 +16,8 @@ const imageStyling = css`
     border-radius: 50%;
     display: block;
     border: 0px;
+    width: 100px;
+    height: 100px;
 `;
 
 const creditStyling = css`
@@ -106,11 +102,7 @@ export const Body = ({
 }): JSX.Element => {
     return (
         <div>
-            {image && (
-                <span className={'forceHeightAndWidth'}>
-                    <img className={imageStyling} src={image} alt="" />
-                </span>
-            )}
+            {image && <img className={imageStyling} src={image} alt="" />}
             <div
                 className={cx(bodyStyling, linkStyling(pillar))}
                 dangerouslySetInnerHTML={{


### PR DESCRIPTION
## What does this change?
Remove  `forceHeightAndWidth` as a className and instead put the styles within the image component
