### PR TITLE
Add titlebar colouring

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,7 @@
 {
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "workbench.colorCustomizations": {
+        "titleBar.activeBackground": "#FFB000",
+        "titleBar.activeForeground": "#000000"
+    }
 }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Adds titlebar colouring to make it easier to distinguish between projects.
![image](https://user-images.githubusercontent.com/9122944/106131030-1019a880-615a-11eb-8be1-3d2afcd1af5b.png)

Colouring is based on this colour palette https://davidmathlogic.com/colorblind/#%23648FFF-%23785EF0-%23DC267F-%23FE6100-%23FFB000