### PR TITLE
Correct the `InteractiveAtom` type

### DIFF
--- a/src/InteractiveAtom.tsx
+++ b/src/InteractiveAtom.tsx
@@ -14,10 +14,9 @@ const fullWidthStyles = css`
 type InteractiveAtomType = {
     id: string;
     elementUrl?: string;
-    elementHtml: string;
+    elementHtml?: string;
     elementJs: string;
-    elementCss: string;
-    atomCss?: string; // using css as a props confuses Emotion
+    elementCss?: string;
 };
 
 export const InteractiveAtom = ({


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Updates the prop types of `AtomInteractive` following a recent update that made some optional props compulsory.

