### PR TITLE
Italics now work in Explainers and a story has been added

### DIFF
--- a/src/ExplainerAtom.stories.tsx
+++ b/src/ExplainerAtom.stories.tsx
@@ -5,6 +5,9 @@ import { ExplainerAtom } from './ExplainerAtom';
 const html =
     '<p>Cranes lean in, waiting for an all-clear<br>that will not come.&nbsp;</p><p>Forehead pressed to glass,<br>phone at my ear, I learn</p><p>to sail on your voice<br>over a sadness of building sites,&nbsp;</p><p>past King’s Cross, St Pancras,<br>to the place where you are.</p><p>You say nothing<br>is too far, mothers</p><p>will find their daughters,<br>strangers will be neighbours,</p><p>even saviours<br>will have names.</p><p>You are all flame<br>in a red dress.&nbsp;&nbsp;</p><p>Petals brush my face.<br>You say at last</p><p>the cherry blossom<br>has arrived</p><p>as if that is what<br>we were really waiting for.</p>';
 
+const italicsHTML =
+    '<p>first it was the magic porridge pot<br>absent from the colony of books<br>when I’d gone home&nbsp; &nbsp; &nbsp;back to my bedroom<br>hungry for what I missed of my childhood</p><p>weeks later&nbsp; &nbsp; &nbsp;<i>the enormous turnip</i><br> and then <i>the three billy goats gruff</i><br>cantered off &nbsp; &nbsp; &nbsp;and no-one noticed<br> the small black swarm of letters that hung<br>&nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp;in the air like dust&nbsp; &nbsp; &nbsp;and then were gone</p><p>at first people seemed to remember<br> the stories&nbsp; &nbsp; &nbsp;but then they started<br>forgetting &nbsp; &nbsp; &nbsp;<i>how big had the turnip been?<br>had there really been a turnip? </i></p><p>and then there was no turnip&nbsp; &nbsp; &nbsp;no goats<br> in the field &nbsp; &nbsp; &nbsp;and all the shelves were empty<br>and all the streets silent </p><p>* </p><p>when I was a boy &nbsp; &nbsp; &nbsp;mum placed in my hand<br>a ladybird that contained an entire<br>treasure island&nbsp; &nbsp; &nbsp;now&nbsp; &nbsp; &nbsp;back at my house<br>one page flaps at the back of the bookcase </p><p>I hold it&nbsp; &nbsp; &nbsp;its simple intricacy<br> its worlds within worlds&nbsp; &nbsp; &nbsp;as it stops moving<br>and dissolves to tissue&nbsp; &nbsp; &nbsp;and becomes<br> a ghost of itself&nbsp; &nbsp; &nbsp;in my small hands&nbsp;</p><p><br></p>';
+
 export default {
     title: 'ExplainerAtom',
     component: ExplainerAtom,
@@ -16,6 +19,16 @@ export const DefaultStory = (): JSX.Element => {
             id="abc123"
             title="Cranes Lean In by Imtiaz Dharker"
             html={html}
+        />
+    );
+};
+
+export const ItalicsStory = (): JSX.Element => {
+    return (
+        <ExplainerAtom
+            id="abc123"
+            title="ladybird by Andrew McMillan"
+            html={italicsHTML}
         />
     );
 };

--- a/src/ExplainerAtom.tsx
+++ b/src/ExplainerAtom.tsx
@@ -30,6 +30,9 @@ const Container = ({
                     margin-top: ${space[3]}px;
                     margin-bottom: ${space[3]}px;
                 }
+                i {
+                    font-style: italic;
+                }
             `}
         >
             {children}
@@ -48,16 +51,22 @@ const Title = ({ title }: { title: string }) => (
     </h3>
 );
 
-const Body = ({ html }: { html: string }) => (
-    <div
-        css={css`
-            ${textSans.small({ fontWeight: 'light', lineHeight: 'tight' })}
-        `}
-        dangerouslySetInnerHTML={{
-            __html: html,
-        }}
-    />
-);
+const Body = ({ html }: { html: string }) => {
+    console.log(html);
+    return (
+        <div
+            css={css`
+                ${textSans.small({
+                    fontWeight: 'light',
+                    lineHeight: 'tight',
+                })}
+            `}
+            dangerouslySetInnerHTML={{
+                __html: html,
+            }}
+        />
+    );
+};
 
 export const ExplainerAtom = ({
     id,

--- a/src/ExplainerAtom.tsx
+++ b/src/ExplainerAtom.tsx
@@ -51,22 +51,19 @@ const Title = ({ title }: { title: string }) => (
     </h3>
 );
 
-const Body = ({ html }: { html: string }) => {
-    console.log(html);
-    return (
-        <div
-            css={css`
-                ${textSans.small({
-                    fontWeight: 'light',
-                    lineHeight: 'tight',
-                })}
-            `}
-            dangerouslySetInnerHTML={{
-                __html: html,
-            }}
-        />
-    );
-};
+const Body = ({ html }: { html: string }) => (
+    <div
+        css={css`
+            ${textSans.small({
+                fontWeight: 'light',
+                lineHeight: 'tight',
+            })}
+        `}
+        dangerouslySetInnerHTML={{
+            __html: html,
+        }}
+    />
+);
 
 export const ExplainerAtom = ({
     id,


### PR DESCRIPTION
## What does this change?

Before all text was inheriting the page style, which overrode any italic styles, especially in the poetry. This should now be fixed

## Images
Before:
![Screenshot 2021-01-29 at 15 15 59](https://user-images.githubusercontent.com/35331926/106292621-f0ab7a00-6244-11eb-8899-d9e4c633a34d.png)

After:
<img width="259" alt="Screenshot 2021-01-29 at 15 06 03" src="https://user-images.githubusercontent.com/35331926/106292457-c063db80-6244-11eb-9fe7-33e3b74242f5.png">



