### PR TITLE
Manage typescript version in package.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
     "workbench.colorCustomizations": {
         "titleBar.activeBackground": "#FFB000",
         "titleBar.activeForeground": "#000000"
-    }
+    },
+    "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
         "pretty-quick": "^3.1.0",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
-        "ts-jest": "^24.3.0"
+        "ts-jest": "^24.3.0",
+        "typescript": "^4.1.3"
     },
     "eslintConfig": {
         "root": true,
@@ -114,7 +115,8 @@
         "preact": "^10.5.7",
         "preact-render-to-string": "^5.1.12",
         "react": "^16.14.0",
-        "react-dom": "^16.14.0"
+        "react-dom": "^16.14.0",
+        "typescript": "^4.1.3"
     },
     "jest": {
         "testEnvironment": "jest-environment-jsdom-sixteen",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14675,6 +14675,11 @@ typescript@^3.8.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.3.tgz#d3ac8883a97c26139e42df5e93eeece33d610b8a"
   integrity sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==
 
+typescript@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
+  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
+
 unfetch@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.1.0.tgz#6ec2dd0de887e58a4dee83a050ded80ffc4137db"


### PR DESCRIPTION
## What does this change?
- Explicitly set typescript version in `devDependencies` and `peerDependencies`
- VSC fetch typescript version for `node_modules`

## Why?
Using JSX instead of React throws TS issues for older versions of TS. To avoid these issues we should remove the ambiguity of what TS version is running in the repo
