### PR TITLE
Update react 17

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -7,15 +7,22 @@ module.exports = {
             options: {
                 presets: [
                     '@babel/preset-typescript',
-                    '@emotion/babel-preset-css-prop',
+                    [
+                        '@babel/preset-react',
+                        {
+                            runtime: 'automatic',
+                            importSource: '@emotion/core',
+                        },
+                    ],
                     [
                         '@babel/preset-env',
                         {
                             targets: {
-                                esmodules: true,
+                                ie: '11',
                             },
                         },
                     ],
+                    '@emotion/babel-preset-css-prop',
                 ],
             },
         });

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -7,22 +7,15 @@ module.exports = {
             options: {
                 presets: [
                     '@babel/preset-typescript',
-                    [
-                        '@babel/preset-react',
-                        {
-                            runtime: 'automatic',
-                            importSource: '@emotion/core',
-                        },
-                    ],
+                    '@babel/preset-react',
                     [
                         '@babel/preset-env',
                         {
                             targets: {
-                                ie: '11',
+                                esmodules: true,
                             },
                         },
                     ],
-                    '@emotion/babel-preset-css-prop',
                 ],
             },
         });

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,13 +1,8 @@
 module.exports = {
     presets: [
         '@babel/preset-typescript',
-        [
-            '@babel/preset-react',
-            {
-                runtime: 'automatic',
-                importSource: '@emotion/core',
-            },
-        ],
+        ['@babel/preset-react', { pragma: 'h', pragmaFrag: 'Fragment' }],
+        '@emotion/babel-preset-css-prop',
         [
             '@babel/preset-env',
             {
@@ -16,7 +11,6 @@ module.exports = {
                 },
             },
         ],
-        '@emotion/babel-preset-css-prop',
     ],
     plugins: ['@babel/plugin-proposal-optional-chaining'],
     env: {

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,8 +1,13 @@
 module.exports = {
     presets: [
         '@babel/preset-typescript',
-        ['@babel/preset-react', { pragma: 'h', pragmaFrag: 'Fragment' }],
-        '@emotion/babel-preset-css-prop',
+        [
+            '@babel/preset-react',
+            {
+                runtime: 'automatic',
+                importSource: '@emotion/core',
+            },
+        ],
         [
             '@babel/preset-env',
             {
@@ -11,6 +16,7 @@ module.exports = {
                 },
             },
         ],
+        '@emotion/babel-preset-css-prop',
     ],
     plugins: ['@babel/plugin-proposal-optional-chaining'],
     env: {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
         "eslint-config-prettier": "^6.15.0",
         "eslint-plugin-prettier": "^3.2.0",
         "eslint-plugin-react": "^7.21.5",
-        "eslint-plugin-react-hooks": "^4.2.0",
         "husky": "^4.3.0",
         "jest": "^26.6.3",
         "jest-environment-jsdom-sixteen": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
         "@testing-library/jest-dom": "^5.11.6",
         "@testing-library/react": "^11.2.2",
         "@types/jest": "^26.0.15",
-        "@types/react-dom": "^16.9.9",
+        "@types/react": "^17.0.1",
+        "@types/react-dom": "^17.0.0",
         "@types/youtube": "^0.0.39",
         "@typescript-eslint/eslint-plugin": "^4.0.0",
         "@typescript-eslint/parser": "^3.10.1",
@@ -70,8 +71,8 @@
         "preact-render-to-string": "^5.1.12",
         "prettier": "^2.1.2",
         "pretty-quick": "^3.1.0",
-        "react": "^16.14.0",
-        "react-dom": "^16.14.0",
+        "react": "^17.0.1",
+        "react-dom": "^17.0.1",
         "ts-jest": "^24.3.0"
     },
     "eslintConfig": {
@@ -81,6 +82,8 @@
         ],
         "parser": "@typescript-eslint/parser",
         "plugins": [
+            "react",
+            "react-hooks",
             "@emotion",
             "@typescript-eslint"
         ],
@@ -96,7 +99,10 @@
             "@emotion/styled-import": "error",
             "no-unused-vars": "off",
             "@typescript-eslint/no-unused-vars": "off",
-            "@typescript-eslint/no-unused-vars-experimental": "error"
+            "@typescript-eslint/no-unused-vars-experimental": "error",
+            "react-hooks/exhaustive-deps": "warn",
+            "react/jsx-uses-react": "off",
+            "react/react-in-jsx-scope": "off"
         }
     },
     "husky": {
@@ -133,7 +139,8 @@
         "globals": {
             "ts-jest": {
                 "diagnostics": false,
-                "tsConfigFile": "tsconfig.json"
+                "tsConfigFile": "tsconfig.json",
+                "babelConfig": true
             }
         },
         "testMatch": [

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
         "eslint-config-prettier": "^6.15.0",
         "eslint-plugin-prettier": "^3.2.0",
         "eslint-plugin-react": "^7.21.5",
+        "eslint-plugin-react-hooks": "^4.2.0",
         "husky": "^4.3.0",
         "jest": "^26.6.3",
         "jest-environment-jsdom-sixteen": "^1.0.3",

--- a/src/Answers.stories.tsx
+++ b/src/Answers.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css } from '@emotion/core';
 
 import { Radio } from '@guardian/src-radio';

--- a/src/Answers.tsx
+++ b/src/Answers.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css } from '@emotion/core';
 
 import { SvgCheckmark, SvgCross } from '@guardian/src-icons';

--- a/src/AudioAtom.stories.tsx
+++ b/src/AudioAtom.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css } from '@emotion/core';
 
 import { Pillar } from '@guardian/types';

--- a/src/AudioAtom.test.tsx
+++ b/src/AudioAtom.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { render } from '@testing-library/react';
 import { screen, fireEvent } from '@testing-library/dom';

--- a/src/AudioAtom.tsx
+++ b/src/AudioAtom.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, MouseEvent } from 'react';
-import { css, jsx } from '@emotion/core';
+import { css } from '@emotion/core';
 
 import { textSans, headline } from '@guardian/src-foundations/typography';
 import { palette } from '@guardian/src-foundations';

--- a/src/AudioAtom.tsx
+++ b/src/AudioAtom.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect, useRef, MouseEvent } from 'react';
-import { css } from '@emotion/core';
+import { useState, useEffect, useRef, MouseEvent } from 'react';
+import { css, jsx } from '@emotion/core';
 
 import { textSans, headline } from '@guardian/src-foundations/typography';
 import { palette } from '@guardian/src-foundations';

--- a/src/ChartAtom.stories.tsx
+++ b/src/ChartAtom.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 import { ChartAtom } from './ChartAtom';
 import { html } from './fixtures/chartAtoms';

--- a/src/ChartAtom.test.tsx
+++ b/src/ChartAtom.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { render } from '@testing-library/react';
 import { html } from './fixtures/chartAtoms';

--- a/src/ChartAtom.tsx
+++ b/src/ChartAtom.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css } from '@emotion/core';
 import { space } from '@guardian/src-foundations';
 

--- a/src/ExplainerAtom.stories.tsx
+++ b/src/ExplainerAtom.stories.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { ExplainerAtom } from './ExplainerAtom';
 
 const html =

--- a/src/ExplainerAtom.test.tsx
+++ b/src/ExplainerAtom.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { render } from '@testing-library/react';
 

--- a/src/ExplainerAtom.tsx
+++ b/src/ExplainerAtom.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css } from '@emotion/core';
 
 import { headline, textSans } from '@guardian/src-foundations/typography';

--- a/src/GuideAtom.stories.tsx
+++ b/src/GuideAtom.stories.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { GuideAtom } from './GuideAtom';
 import {
     defaultStoryExpanded,

--- a/src/GuideAtom.test.tsx
+++ b/src/GuideAtom.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { render, fireEvent } from '@testing-library/react';
 

--- a/src/GuideAtom.tsx
+++ b/src/GuideAtom.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { GuideAtomType } from './types';
 import { Footer } from './expandableAtom/Footer';
 import { Container } from './expandableAtom/Container';

--- a/src/InteractiveAtom.stories.tsx
+++ b/src/InteractiveAtom.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css } from '@emotion/core';
 
 import { InteractiveAtomBlockElement } from './fixtures/InteractiveAtomBlockElement';

--- a/src/InteractiveAtom.tsx
+++ b/src/InteractiveAtom.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css } from '@emotion/core';
 
 import { unifyPageContent } from './lib/unifyPageContent';

--- a/src/KnowledgeQuiz.stories.tsx
+++ b/src/KnowledgeQuiz.stories.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { KnowledgeQuizAtom } from './KnowledgeQuiz';
 import {
     exampleKnowledgeQuestions,

--- a/src/KnowledgeQuiz.test.tsx
+++ b/src/KnowledgeQuiz.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { render, fireEvent } from '@testing-library/react';
 

--- a/src/KnowledgeQuiz.tsx
+++ b/src/KnowledgeQuiz.tsx
@@ -1,4 +1,4 @@
-import React, { useState, Fragment, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { css } from '@emotion/core';
 
 import { body, textSans } from '@guardian/src-foundations/typography';
@@ -218,7 +218,7 @@ const Answers = ({
 }) => {
     if (hasSubmitted) {
         return (
-            <Fragment>
+            <>
                 {answers.map((answer) => {
                     const isSelected = selectedAnswerId === answer.id;
 
@@ -264,7 +264,7 @@ const Answers = ({
                         />
                     );
                 })}
-            </Fragment>
+            </>
         );
     }
 

--- a/src/PersonalityQuiz.stories.tsx
+++ b/src/PersonalityQuiz.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css } from '@emotion/core';
 
 import { PersonalityQuizAtom } from './PersonalityQuiz';

--- a/src/PersonalityQuiz.test.tsx
+++ b/src/PersonalityQuiz.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { render, fireEvent } from '@testing-library/react';
 

--- a/src/PersonalityQuiz.tsx
+++ b/src/PersonalityQuiz.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
     useState,
     KeyboardEvent,
     useEffect,

--- a/src/Picture.tsx
+++ b/src/Picture.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css } from '@emotion/core';
 
 import { breakpoints } from '@guardian/src-foundations/mq';

--- a/src/ProfileAtom.stories.tsx
+++ b/src/ProfileAtom.stories.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { Pillar } from '@guardian/types';
 import { ProfileAtom } from './ProfileAtom';
 

--- a/src/ProfileAtom.test.tsx
+++ b/src/ProfileAtom.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import '@testing-library/jest-dom/extend-expect';
 import { render, fireEvent } from '@testing-library/react';
 

--- a/src/ProfileAtom.tsx
+++ b/src/ProfileAtom.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { ProfileAtomType } from './types';
 import { Container } from './expandableAtom/Container';
 import { Footer } from './expandableAtom/Footer';

--- a/src/QandaAtom.stories.tsx
+++ b/src/QandaAtom.stories.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { QandaAtom } from './QandaAtom';
 import {
     imageStoryExpanded,

--- a/src/QandaAtom.test.tsx
+++ b/src/QandaAtom.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { render, fireEvent } from '@testing-library/react';
 

--- a/src/QandaAtom.tsx
+++ b/src/QandaAtom.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { QandaAtomType } from './types';
 import { Container } from './expandableAtom/Container';
 import { Footer } from './expandableAtom/Footer';

--- a/src/TimelineAtom.stories.tsx
+++ b/src/TimelineAtom.stories.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { TimelineAtom } from './TimelineAtom';
 import {
     noTimelineEventsStoryExpanded,

--- a/src/TimelineAtom.test.tsx
+++ b/src/TimelineAtom.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { render, fireEvent } from '@testing-library/react';
 

--- a/src/TimelineAtom.tsx
+++ b/src/TimelineAtom.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css } from '@emotion/core';
 
 import { neutral, brandAlt, space, remSpace } from '@guardian/src-foundations';

--- a/src/VideoAtom.stories.tsx
+++ b/src/VideoAtom.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css } from '@emotion/core';
 
 import { VideoAtom } from './VideoAtom';

--- a/src/VideoAtom.tsx
+++ b/src/VideoAtom.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { VideoAtomType } from './types';
 import { MaintainAspectRatio } from './common/MaintainAspectRatio';
 

--- a/src/YoutubeAtom.stories.tsx
+++ b/src/YoutubeAtom.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css } from '@emotion/core';
 
 import { YoutubeAtom } from './YoutubeAtom';

--- a/src/YoutubeAtom.test.tsx
+++ b/src/YoutubeAtom.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import { render } from '@testing-library/react';
 

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { css } from '@emotion/core';
 import YouTubePlayer from 'youtube-player';
 import { pillarPalette } from './lib/pillarPalette';

--- a/src/common/MaintainAspectRatio.tsx
+++ b/src/common/MaintainAspectRatio.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css } from '@emotion/core';
 
 export const MaintainAspectRatio = ({

--- a/src/expandableAtom/Body.tsx
+++ b/src/expandableAtom/Body.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css } from '@emotion/core';
 
 import { neutral } from '@guardian/src-foundations/palette';

--- a/src/expandableAtom/Container.tsx
+++ b/src/expandableAtom/Container.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { css } from '@emotion/core';
 
 import { neutral, text } from '@guardian/src-foundations/palette';

--- a/src/expandableAtom/Footer.tsx
+++ b/src/expandableAtom/Footer.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { css } from '@emotion/core';
 
 import { textSans } from '@guardian/src-foundations/typography';

--- a/src/expandableAtom/Summary.tsx
+++ b/src/expandableAtom/Summary.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { css } from '@emotion/core';
 
 import { textSans, headline, body } from '@guardian/src-foundations/typography';

--- a/src/lib/unifyPageContent.tsx
+++ b/src/lib/unifyPageContent.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import render from 'preact-render-to-string';
 
 export const unifyPageContent = ({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
         "outDir": "dist",
         "strict": true,
         "esModuleInterop": true,
-        "jsx": "react",
+        "jsx": "react-jsx",
         "moduleResolution": "node",
         "allowJs": true,
         "skipLibCheck": true,
@@ -14,7 +14,7 @@
         "forceConsistentCasingInFileNames": true,
         "resolveJsonModule": true,
         "isolatedModules": false,
-        "noEmit": false,
+        "noEmit": false
     },
     "files": ["src/types.ts", "src/content.d.ts"],
     "include": ["src/"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -6825,6 +6825,11 @@ eslint-plugin-prettier@^3.2.0:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-react-hooks@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz#8c229c268d468956334c943bb45fc860280f5556"
+  integrity sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==
+
 eslint-plugin-react@^7.21.5:
   version "7.21.5"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.21.5.tgz#50b21a412b9574bfe05b21db176e8b7b3b15bff3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3362,10 +3362,10 @@
     "@types/react" "*"
     "@types/reactcss" "*"
 
-"@types/react-dom@^16.9.9":
-  version "16.9.9"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.9.tgz#d2d0a6f720a0206369ccbefff752ba37b9583136"
-  integrity sha512-jE16FNWO3Logq/Lf+yvEAjKzhpST/Eac8EMd1i4dgZdMczfgqC8EjpxwNgEe3SExHYLliabXDh9DEhhqnlXJhg==
+"@types/react-dom@^17.0.0":
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.0.tgz#b3b691eb956c4b3401777ee67b900cb28415d95a"
+  integrity sha512-lUqY7OlkF/RbNtD5nIq7ot8NquXrdFrjSOR6+w9a9RFQevGi1oZO1dcJbXMeONAPKtZ2UrZOEJ5UOCVsxbLk/g==
   dependencies:
     "@types/react" "*"
 
@@ -3383,6 +3383,14 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
+
+"@types/react@^17.0.1":
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.1.tgz#eb1f1407dea8da3bc741879c1192aa703ab9975b"
+  integrity sha512-w8t9f53B2ei4jeOqf/gxtc2Sswnc3LBK5s0DyJcg5xd10tMHXts2N31cKjWfH9IC/JvEPa/YF1U4YeP1t4R6HQ==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^3.0.2"
 
 "@types/reactcss@*":
   version "1.2.3"
@@ -6054,6 +6062,11 @@ csstype@^2.2.0, csstype@^2.5.7:
   version "2.6.10"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.10.tgz#e63af50e66d7c266edb6b32909cfd0aabe03928b"
   integrity sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==
+
+csstype@^3.0.2:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.6.tgz#865d0b5833d7d8d40f4e5b8a6d76aea3de4725ef"
+  integrity sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw==
 
 cyclist@^1.0.1:
   version "1.0.1"
@@ -12562,15 +12575,14 @@ react-docgen@^5.0.0:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-react-dom@^16.14.0:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
-  integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
+react-dom@^17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.1.tgz#1de2560474ec9f0e334285662ede52dbc5426fc6"
+  integrity sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
+    scheduler "^0.20.1"
 
 react-draggable@^4.0.3:
   version "4.4.2"
@@ -12683,14 +12695,13 @@ react-textarea-autosize@^8.1.1:
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
 
-react@^16.14.0:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
-  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
+react@^17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.1.tgz#6e0600416bd57574e3f86d92edba3d9008726127"
+  integrity sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
 
 reactcss@^1.2.0:
   version "1.2.3"
@@ -13375,10 +13386,10 @@ saxes@^5.0.0:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@^0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
-  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
+scheduler@^0.20.1:
+  version "0.20.1"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.1.tgz#da0b907e24026b01181ecbc75efdc7f27b5a000c"
+  integrity sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6825,11 +6825,6 @@ eslint-plugin-prettier@^3.2.0:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-eslint-plugin-react-hooks@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz#8c229c268d468956334c943bb45fc860280f5556"
-  integrity sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==
-
 eslint-plugin-react@^7.21.5:
   version "7.21.5"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.21.5.tgz#50b21a412b9574bfe05b21db176e8b7b3b15bff3"


### PR DESCRIPTION
## What does this change?
Update to React 17 and remove `React` from import scope

## Why?
Emotion 10 uses JSX pragma, and `React` 17 favors JSX over JS. To make Emotion upgrade easier, we should first update `React`

## Changes
- Update React, react types
- Remove React as an import
- Update `@babel/preset-react` options to use `runtime: 'automatic',` and `importSource: '@emotion/core',`
- Add `eslint-plugin-react-hooks`


## Link to supporting Trello card
https://trello.com/c/Wlpg47zl/2410-update-to-react-17