### PR TITLE
Update source v3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
         "@emotion/babel-preset-css-prop": "10.0.27",
         "@emotion/eslint-plugin": "^11.0.0",
         "@emotion/react": "^11.1.5",
-        "@guardian/src-button": "2.4.0",
-        "@guardian/src-foundations": "^2.6.0",
-        "@guardian/src-icons": "^2.5.0",
-        "@guardian/src-radio": "^2.7.1",
+        "@guardian/src-button": "^3.2.1",
+        "@guardian/src-foundations": "^3.2.1",
+        "@guardian/src-icons": "^3.2.1",
+        "@guardian/src-radio": "^3.2.1",
         "@guardian/types": "^3.0.0",
         "@storybook/addon-docs": "^6.1.11",
         "@storybook/addons": "^6.1.11",
@@ -113,10 +113,10 @@
     },
     "peerDependencies": {
         "@emotion/react": "^11.1.5",
-        "@guardian/src-button": "2.4.0",
-        "@guardian/src-foundations": "^2.6.0",
-        "@guardian/src-icons": "^2.5.0",
-        "@guardian/src-radio": "^2.7.1",
+        "@guardian/src-button": "^3.2.1",
+        "@guardian/src-foundations": "^3.2.1",
+        "@guardian/src-icons": "^3.2.1",
+        "@guardian/src-radio": "^3.2.1",
         "@guardian/types": "^3.0.0",
         "preact": "^10.5.7",
         "preact-render-to-string": "^5.1.12",
@@ -147,9 +147,6 @@
         "testMatch": [
             "**/*.test.+(ts|tsx|js)"
         ],
-        "moduleNameMapper": {
-            "^@guardian/src-foundations/(.*)(?<!cjs)$": "@guardian/src-foundations/$1/cjs"
-        },
         "collectCoverageFrom": [
             "src/**/*.{ts,tsx}"
         ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
         "strict": true,
         "esModuleInterop": true,
         "jsx": "react-jsx",
+        "jsxImportSource": "@emotion/react",
         "moduleResolution": "node",
         "allowJs": true,
         "skipLibCheck": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1489,63 +1489,53 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@guardian/src-button@2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-button/-/src-button-2.4.0.tgz#44c7300fea0c78e09ea67deae67fed56aea3b820"
-  integrity sha512-HqtrfsYlp+Cld9fH3IPO29KSfjCDTYF8Xs06LLqyEJq28Ti8nXZ457GmF9mYYV6AOPDhWDZUFjPbvSpGAKNIqw==
+"@guardian/src-button@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-button/-/src-button-3.2.1.tgz#b12725799f364c85ca2279b0d4e5ff72a61c9bfc"
+  integrity sha512-3JzTV8wHPJa3ydGa4tvhdGUiNGZEwCr2i2Fq6AHnH2Qe1vS48MmU/W0P1RqDR/PlgtSdC26cvsEpuZfhC5ECTw==
   dependencies:
-    "@guardian/src-helpers" "^2.4.0"
+    "@guardian/src-helpers" "^3.2.1"
 
-"@guardian/src-foundations@^2.6.0":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-2.6.0.tgz#f81466321a125994444167eaa3928dbbbfca7a2e"
-  integrity sha512-r1eUesgetq0jJc0vt1f+b07PtkQ44AzytsW1tGmdirtthF28FBWoVJ5QcFcebL/Ou47xNQi+BhqC8VKbjMFbrg==
+"@guardian/src-foundations@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-3.2.1.tgz#190f709f8bfd38d338c1fa96bff4f1c7509ee977"
+  integrity sha512-oYY1P874XV5zxv25L3Sdkek02diwEqjSHDqf7GtGtA1gxt6fEdzgukugtE851S81alIkZqSfVeZDty9R8YwXnQ==
 
-"@guardian/src-foundations@^2.7.1":
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-2.7.1.tgz#d245a5ebedd520bf3be1b10ff7c5a0b5962a0a03"
-  integrity sha512-U0XVJWugB6vXoORZPcfvnISAhwaIM5/Pz5uGj628+OcqF3vwm0dBUt1UTesVqOsG7tVUQvGG/n96wXWjGwmVmQ==
-
-"@guardian/src-helpers@^2.4.0", "@guardian/src-helpers@^2.7.1":
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/@guardian/src-helpers/-/src-helpers-2.7.1.tgz#b16834473f7f89716f7d98c60f3394e4bb6a3305"
-  integrity sha512-HGc+hkBq+ltlCeRrgsJ5a+tpGnvVg8iZgzOxkzeiMTCxbR8c5vtogFx51trgvb5sH5780UoDFh0ACGY1xyMamw==
+"@guardian/src-helpers@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-helpers/-/src-helpers-3.2.1.tgz#3ddb356d1112e5f96f11feee9238d26313fdebde"
+  integrity sha512-p9SwSZJsjxId/lsCgEeMahAFJIngHtni2IIHGvyeKYvWm4k4YsXZKQUyZ0P2rxTwz0oTc3xR9D4IPw11OsL/YA==
   dependencies:
-    "@guardian/src-foundations" "^2.7.1"
+    "@guardian/src-foundations" "^3.2.1"
 
-"@guardian/src-icons@^2.5.0":
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-icons/-/src-icons-2.5.0.tgz#a84364a9285778fd3f5b752eb96c09fe03e07678"
-  integrity sha512-8RPxI+fYLwKP5ffM2BudF2/K66aw2viOyx67buEFq/+R6aFXlJft9ImNvtDCXKZLRzki8hnLc6yRhv1SihHfkA==
+"@guardian/src-icons@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-icons/-/src-icons-3.2.1.tgz#7b74326a32be80bf808d39ba65edad0fea56536a"
+  integrity sha512-Jt/+ntzbb2eshbDQvXOan1yRNBxbK2Ga8xr+H2/60k4W00aZjBu0QgXELQ1c2qQXjaVdSQK3216kGy6BqQSdSw==
 
-"@guardian/src-icons@^2.7.1":
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/@guardian/src-icons/-/src-icons-2.7.1.tgz#600ba5a16fd3857657360632caac1b2f38740829"
-  integrity sha512-gQ7XrH3R++kZOXSK4e5ajRrUxNMgzQH7LiQ4HSYH51mJceh3YWtsc4934O5sCpJjJjhFiWGYubbg4BG14smUPg==
-
-"@guardian/src-label@^2.7.1":
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/@guardian/src-label/-/src-label-2.7.1.tgz#3f0a640a0970452015f51aff0c6395035f396240"
-  integrity sha512-ThMbUpZt73taW6AteFvO7Soqj/AYFo9gfWZsCImKh5iGRH2z9zewlgZtL4EA12qOLoLVjBDdL27goZomRYcT3g==
+"@guardian/src-label@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-label/-/src-label-3.2.1.tgz#de4b940dd5965b674520d99640851815ec1c027f"
+  integrity sha512-us4X3MmfkQJCq1MSxhFGFskq+rzhZ5ZpqUKD5CMb5+co11heqJ2373to6+0ku/nOGqzWbTSao/D0htuNsuYWuA==
   dependencies:
-    "@guardian/src-helpers" "^2.7.1"
+    "@guardian/src-helpers" "^3.2.1"
 
-"@guardian/src-radio@^2.7.1":
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/@guardian/src-radio/-/src-radio-2.7.1.tgz#5e38e67533c124f7908251587eb865e626ccec2a"
-  integrity sha512-1v8Pj/c0NQkNEaYVpo2hPDelnHBNBU3DUXA8DPqnmIUp5Dro8I+r3Mkt6suhYTe2zawwCmbQBBfA/yGBsL0mxg==
+"@guardian/src-radio@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-radio/-/src-radio-3.2.1.tgz#03db47e275d7bc69b004a8c38ba6a2c84e83b5c3"
+  integrity sha512-TBgQXHuWRFZ6XaxVoUih1cvaOk/wJUrrIGO6KeWx1oKQtTrxzgfTK8oWXJZco+TOCoxBqtwQeDPfhda34X0VbA==
   dependencies:
-    "@guardian/src-helpers" "^2.7.1"
-    "@guardian/src-label" "^2.7.1"
-    "@guardian/src-user-feedback" "^2.7.1"
+    "@guardian/src-helpers" "^3.2.1"
+    "@guardian/src-label" "^3.2.1"
+    "@guardian/src-user-feedback" "^3.2.1"
 
-"@guardian/src-user-feedback@^2.7.1":
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/@guardian/src-user-feedback/-/src-user-feedback-2.7.1.tgz#aa27c9179509267870d60e323c5cb6d04f53adb4"
-  integrity sha512-FLMuAJDEYNwdlypn35aKpzU7BK5NuatdLDGGrO/D+YrJ/o0N8mlGNAYWBMPFoLgcFvh+v1borTUjOhIaNgtkyA==
+"@guardian/src-user-feedback@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-user-feedback/-/src-user-feedback-3.2.1.tgz#ba60a5aea7046bdd880ba1ad5d5d47c80e350811"
+  integrity sha512-sVG8Zjb9aB+BX5790BEOV6JgkhIupXrgFfzEl+bhuXAY4mDFE6dJAdItz5KIJ8CR5lKsHyET1XfjLYy159GUSA==
   dependencies:
-    "@guardian/src-helpers" "^2.7.1"
-    "@guardian/src-icons" "^2.7.1"
+    "@guardian/src-helpers" "^3.2.1"
+    "@guardian/src-icons" "^3.2.1"
 
 "@guardian/types@^3.0.0":
   version "3.0.0"


### PR DESCRIPTION
## What does this change?
- Update source packages ot v3.2
- remove `moduleNameMapper` as its is no longer needed
- `jsxImportSource` set to `@emotion/react`

## what is jsxImportSource?
`jsxImportSource` is used to determin the JSX runtime to be used. In our case as we use `css` as an attribute we need to run the project though Emotion's runtime
