### PR TITLE
Update Locations Of Index Files

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "version": "12.0.0",
     "source": "src/index.ts",
     "main": "dist/index.js",
-    "module": "dist/index.modern.js",
-    "unpkg": "dist/index.umd.js",
+    "module": "dist/index.esm.js",
     "publishConfig": {
         "access": "public"
     },


### PR DESCRIPTION
## Why?

As a result of the [migration to rollup](https://github.com/guardian/atoms-rendering/blob/24b166fc40d125b33ae9ac56d3535c27b0ff5304/rollup.config.js#L18), the ES modules entry point is now `dist/index.esm.js`. This updates the `module` field in `package.json` to reflect this, so that consumers (such as bundlers like webpack) know where to look.

It also removes a reference to the `unpkg` entry point, as I don't think this is built any more?

## Changes

- Clarified that the `module` entry-point is now `dist/index.esm.js`
- Removed `unpkg` entry point as it no longer exists
