### PR TITLE
Correctly sets YouTube atom data attributes

### DIFF
--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -28,6 +28,7 @@ type Props = {
     origin?: string;
     eventEmitters: ((event: VideoEventKey) => void)[];
     pillar: Theme;
+    atomId?: string;
 };
 declare global {
     interface Window {
@@ -181,6 +182,7 @@ export const YoutubeAtom = ({
     origin,
     eventEmitters,
     pillar,
+    atomId,
 }: Props): JSX.Element => {
     const embedConfig =
         adTargeting && JSON.stringify(buildEmbedConfig(adTargeting));
@@ -294,8 +296,8 @@ export const YoutubeAtom = ({
                 allow="autoplay"
                 tabIndex={overrideImage || posterImage ? -1 : 0}
                 allowFullScreen
-                data-atom-id={`youtube-video-${assetId}`}
-                data-atom-type="youtube"
+                data-atom-id={atomId}
+                data-atom-type="media"
             />
 
             {(overrideImage || posterImage) && (


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR aims to fix a user reported issue with the Teleporter `Copy Embed Link` behaviour for YouTube atoms. The way the current data attributes are configured means the outputted link is incorrect. The `data-atom-id` should be set to the id of the media atom and the `data-atom-type` should be set to "media".

This change is designed to account for the issues a change to the interface might cause by making the new property optional. The upgrade is also only significant for DCR, as this is what Teleporter uses.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
I have attempted to test this using npm link but I found the video player didn't work with or without my change. It does however work when the package isn't linked. I would be interested in pairin g on testing this if anyone knows where I'm going wrong. 

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Users can press the `Copy Embed Link` button and be confident it will work as expected.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
Any change to the interface can be frustrating to implement in each of the consumers. This change attempts to mitigate problems by making the necessary parameter optional.

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [x] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
