### PR TITLE
Consistent themed fonts for quizzes

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,4 +107,5 @@ Then:
 Once complete, you can update the version of `@guardian/atoms-rendering` in any consuming project to see the changes
 
 ## Snyk Code Scanning
+
 There's a Github action set up on the repository to scan for vulnerabilities. This is set to "continue on error" and so will show a green tick regardless. In order to check the vulnerabilities we can use the Github code scanning feature in the security tab and this will list all vulnerabilities for a given branch etc. You should use this if adding/removing/updating packages to see if there are any vulnerabilities.

--- a/src/Answers.tsx
+++ b/src/Answers.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
-import { css } from '@emotion/react';
+import { css, SerializedStyles } from '@emotion/react';
 
 import { SvgCheckmark, SvgCross } from '@guardian/src-icons';
 import { neutral, news, success } from '@guardian/src-foundations/palette';
 import { body, textSans } from '@guardian/src-foundations/typography';
 import { space } from '@guardian/src-foundations';
+import { Special, Theme } from '@guardian/types';
 
 // We export Radio wrapper styles to override Source Radio buttons to align
 // with our custom answers for the quiz
-export const radioButtonWrapperStyles = css`
+export const radioButtonWrapperStyles = (theme: Theme): SerializedStyles => css`
     label {
         padding-top: ${space[3]}px;
         padding-bottom: ${space[3]}px;
@@ -25,10 +26,13 @@ export const radioButtonWrapperStyles = css`
         /* TODO: apply same styles on focus (requires source update) */
 
         div {
-            ${body.medium()};
+            ${fontStyles(theme)};
         }
     }
 `;
+
+const fontStyles = (theme: Theme) =>
+    theme === Special.Labs ? textSans.medium() : body.medium();
 
 const answerWithSVGStyles = css`
     margin-bottom: ${space[2]}px;
@@ -95,11 +99,13 @@ const WhiteText = ({
     supplementText,
     id,
     answerType,
+    theme,
 }: {
     id: string;
     text: string;
     supplementText?: string;
     answerType: string;
+    theme: Theme;
 }) => (
     <label
         css={css`
@@ -107,14 +113,14 @@ const WhiteText = ({
             display: flex;
             flex-direction: column;
 
-            ${body.medium()};
+            ${fontStyles(theme)};
         `}
         data-testid={id}
         data-answer-type={answerType}
     >
         <span
             css={css`
-                ${body.medium()};
+                ${fontStyles(theme)};
             `}
         >
             {text}
@@ -136,11 +142,13 @@ const BlackText = ({
     supplementText,
     id,
     answerType,
+    theme,
 }: {
     id: string;
     text: string;
     supplementText?: string;
     answerType: string;
+    theme: Theme;
 }) => (
     <label
         css={css`
@@ -148,14 +156,14 @@ const BlackText = ({
             display: flex;
             flex-direction: column;
 
-            ${body.medium()};
+            ${fontStyles(theme)};
         `}
         data-testid={id}
         data-answer-type={answerType}
     >
         <span
             css={css`
-                ${body.medium()};
+                ${fontStyles(theme)};
             `}
         >
             {text}
@@ -183,10 +191,12 @@ export const CorrectSelectedAnswer = ({
     answerText,
     explainerText,
     id,
+    theme,
 }: {
     answerText: string;
     explainerText: string;
     id: string;
+    theme: Theme;
 }): JSX.Element => (
     <div css={[answerWithSVGStyles, correctSelectedAnswerStyles]}>
         <WhiteCheckmark />
@@ -195,6 +205,7 @@ export const CorrectSelectedAnswer = ({
             text={answerText}
             supplementText={explainerText}
             answerType="correct-selected-answer"
+            theme={theme}
         />
     </div>
 );
@@ -209,13 +220,20 @@ const incorrectSelectedAnswerStyles = css`
 export const IncorrectAnswer = ({
     answerText,
     id,
+    theme,
 }: {
     answerText: string;
     id: string;
+    theme: Theme;
 }): JSX.Element => (
     <div css={[answerWithSVGStyles, incorrectSelectedAnswerStyles]}>
         <WhiteCross />
-        <WhiteText id={id} text={answerText} answerType="incorrect-answer" />
+        <WhiteText
+            id={id}
+            text={answerText}
+            answerType="incorrect-answer"
+            theme={theme}
+        />
     </div>
 );
 
@@ -232,10 +250,12 @@ export const NonSelectedCorrectAnswer = ({
     answerText,
     explainerText,
     id,
+    theme,
 }: {
     answerText: string;
     explainerText: string;
     id: string;
+    theme: Theme;
 }): JSX.Element => (
     <div css={[answerWithSVGStyles, correctNonSelectedAnswerStyles]}>
         <BlackCheckmark />
@@ -244,6 +264,7 @@ export const NonSelectedCorrectAnswer = ({
             text={answerText}
             supplementText={explainerText}
             answerType="non-selected-correct-answer"
+            theme={theme}
         />
     </div>
 );
@@ -261,15 +282,18 @@ const unselectedAnswerStyles = css`
 export const UnselectedAnswer = ({
     id,
     answerText,
+    theme,
 }: {
     answerText: string;
     id: string;
+    theme: Theme;
 }): JSX.Element => (
     <div css={unselectedAnswerStyles}>
         <BlackText
             id={id}
             text={answerText}
             answerType="unselected-disabled-answer"
+            theme={theme}
         />
     </div>
 );

--- a/src/Answers.tsx
+++ b/src/Answers.tsx
@@ -24,7 +24,7 @@ export const radioButtonWrapperStyles = css`
         }
         /* TODO: apply same styles on focus (requires source update) */
 
-        span {
+        div {
             ${body.medium()};
         }
     }

--- a/src/KnowledgeQuiz.stories.tsx
+++ b/src/KnowledgeQuiz.stories.tsx
@@ -6,6 +6,7 @@ import {
     resultGroups,
 } from './fixtures/knowledgeQuizAtom';
 import { sharingUrls } from './fixtures/sharingUrls';
+import { Pillar, Special } from '@guardian/types';
 
 export default {
     title: 'KnowledgeQuizAtom',
@@ -18,5 +19,16 @@ export const DefaultRendering = (): JSX.Element => (
         questions={exampleKnowledgeQuestions}
         resultGroups={resultGroups}
         sharingUrls={sharingUrls}
+        theme={Pillar.News}
+    />
+);
+
+export const LabsTheme = (): JSX.Element => (
+    <KnowledgeQuizAtom
+        id="2c6bf552-2827-4256-b3a0-f557d215c394"
+        questions={exampleKnowledgeQuestions}
+        resultGroups={resultGroups}
+        sharingUrls={sharingUrls}
+        theme={Special.Labs}
     />
 );

--- a/src/KnowledgeQuiz.tsx
+++ b/src/KnowledgeQuiz.tsx
@@ -17,6 +17,7 @@ import {
     UnselectedAnswer,
     radioButtonWrapperStyles,
 } from './Answers';
+import { Theme, Special } from '@guardian/types';
 
 type AnswerType = {
     id: string;
@@ -38,6 +39,7 @@ type QuizAtomType = {
     questions: QuestionType[];
     resultGroups: ResultGroupsType[];
     sharingUrls: SharingUrlsType;
+    theme: Theme;
 };
 
 type ResultGroupsType = {
@@ -62,6 +64,7 @@ export const KnowledgeQuizAtom = ({
     questions,
     resultGroups,
     sharingUrls,
+    theme,
 }: QuizAtomType): JSX.Element => {
     const [quizSelection, setQuizSelection] = useState<QuizSelectionType>({});
 
@@ -89,6 +92,7 @@ export const KnowledgeQuizAtom = ({
                     answers={question.answers}
                     quizSelection={quizSelection}
                     setQuizSelection={setQuizSelection}
+                    theme={theme}
                 />
             ))}
             {haveAllQuestionsBeenAnswered && (
@@ -112,10 +116,12 @@ export const Question = ({
     number,
     quizSelection,
     setQuizSelection,
+    theme,
 }: QuestionType & {
     number: number;
     quizSelection: QuizSelectionType;
     setQuizSelection: (quizSelection: QuizSelectionType) => void;
+    theme: Theme;
 }): JSX.Element => {
     const [selectedAnswerId, setSelectedAnswerId] = useState<
         string | undefined
@@ -138,7 +144,7 @@ export const Question = ({
     return (
         <div
             css={css`
-                ${body.medium()};
+                ${theme === Special.Labs ? textSans.medium() : body.medium()};
             `}
         >
             <fieldset css={fieldsetStyle}>
@@ -172,6 +178,7 @@ export const Question = ({
                     hasSubmitted={hasSubmitted}
                     selectedAnswerId={selectedAnswerId}
                     setSelectedAnswerId={setSelectedAnswerId}
+                    theme={theme}
                 />
                 <div
                     css={css`
@@ -216,12 +223,14 @@ const Answers = ({
     hasSubmitted,
     selectedAnswerId,
     setSelectedAnswerId,
+    theme,
 }: {
     answers: AnswerType[];
     id: string;
     hasSubmitted: boolean;
     selectedAnswerId?: string;
     setSelectedAnswerId: (selectedAnswerId: string) => void;
+    theme: Theme;
 }) => {
     if (hasSubmitted) {
         return (
@@ -237,6 +246,7 @@ const Answers = ({
                                     id={answer.id}
                                     answerText={answer.text}
                                     explainerText={answer.revealText || ''}
+                                    theme={theme}
                                 />
                             );
                         }
@@ -247,6 +257,7 @@ const Answers = ({
                                     key={answer.id}
                                     id={answer.id}
                                     answerText={answer.text}
+                                    theme={theme}
                                 />
                             );
                         }
@@ -259,6 +270,7 @@ const Answers = ({
                                 id={answer.id}
                                 answerText={answer.text}
                                 explainerText={answer.revealText || ''}
+                                theme={theme}
                             />
                         );
                     }
@@ -268,6 +280,7 @@ const Answers = ({
                             key={answer.id}
                             id={answer.id}
                             answerText={answer.text}
+                            theme={theme}
                         />
                     );
                 })}
@@ -276,7 +289,7 @@ const Answers = ({
     }
 
     return (
-        <div css={radioButtonWrapperStyles}>
+        <div css={radioButtonWrapperStyles(theme)}>
             <RadioGroup name={questionId}>
                 {answers.map((answer) => (
                     <Radio

--- a/src/PersonalityQuiz.stories.tsx
+++ b/src/PersonalityQuiz.stories.tsx
@@ -6,6 +6,7 @@ import {
     exampleResultBuckets,
 } from './fixtures/personalityQuizAtom';
 import { sharingUrls } from './fixtures/sharingUrls';
+import { Pillar, Special } from '@guardian/types';
 
 export default {
     title: 'PersonalityQuizAtom',
@@ -18,5 +19,16 @@ export const DefaultRendering = (): JSX.Element => (
         questions={examplePersonalityQuestions}
         resultBuckets={exampleResultBuckets}
         sharingUrls={sharingUrls}
+        theme={Pillar.News}
+    />
+);
+
+export const LabsTheme = (): JSX.Element => (
+    <PersonalityQuizAtom
+        id="2c6bf552-2827-4256-b3a0-f557d215c394"
+        questions={examplePersonalityQuestions}
+        resultBuckets={exampleResultBuckets}
+        sharingUrls={sharingUrls}
+        theme={Special.Labs}
     />
 );

--- a/src/PersonalityQuiz.tsx
+++ b/src/PersonalityQuiz.tsx
@@ -16,6 +16,7 @@ import { RadioGroup, Radio } from '@guardian/src-radio';
 import { SharingUrlsType } from './types';
 import { radioButtonWrapperStyles } from './Answers';
 import { SharingIcons } from './SharingIcons';
+import { Theme, Special } from '@guardian/types';
 
 type ResultsBucket = {
     id: string;
@@ -43,13 +44,14 @@ type QuizAtomType = {
     questions: QuestionType[];
     resultBuckets: ResultsBucket[];
     sharingUrls: SharingUrlsType;
+    theme: Theme;
 };
 
-const answersWrapperStyle = css`
+const answersWrapperStyle = (theme: Theme) => css`
     margin-bottom: 12px;
     border: 0px;
     padding: 0px;
-    ${body.medium()};
+    ${theme === Special.Labs ? textSans.medium() : body.medium()};
 `;
 
 export const findMostReferredToBucketId = ({
@@ -111,6 +113,7 @@ export const PersonalityQuizAtom = ({
     questions,
     resultBuckets,
     sharingUrls,
+    theme,
 }: QuizAtomType): JSX.Element => {
     const [selectedGlobalAnswers, setSelectedGlobalAnswers] = useState<{
         [key: string]: string;
@@ -193,6 +196,7 @@ export const PersonalityQuizAtom = ({
                             : undefined
                     }
                     hasSubmittedAnswers={hasSubmittedAnswers}
+                    theme={theme}
                 />
             ))}
             {hasMissingAnswers && <MissingAnswers />}
@@ -260,6 +264,7 @@ type PersonalityQuizAnswersProps = {
     updateSelectedAnswer: (selectedAnswerId: string) => void;
     globallySelectedAnswer?: string;
     hasSubmittedAnswers: boolean;
+    theme: Theme;
 };
 
 const PersonalityQuizAnswers = ({
@@ -271,6 +276,7 @@ const PersonalityQuizAnswers = ({
     updateSelectedAnswer,
     globallySelectedAnswer,
     hasSubmittedAnswers,
+    theme,
 }: PersonalityQuizAnswersProps) => {
     // use local state to avoid re-renders of AnswersGroup from updates due to: updateSelectedAnswer & selectedAnswer
     const [selectedAnswer, setSelectedAnswers] = useState<string | undefined>();
@@ -287,7 +293,7 @@ const PersonalityQuizAnswers = ({
     }, [globallySelectedAnswer, setSelectedAnswers]);
 
     return (
-        <fieldset css={answersWrapperStyle}>
+        <fieldset css={answersWrapperStyle(theme)}>
             <div>
                 <legend
                     css={css`
@@ -318,6 +324,7 @@ const PersonalityQuizAnswers = ({
                 answers={answers}
                 selectedAnswer={selectedAnswer}
                 setSelectedAnswers={setSelectedAnswers}
+                theme={theme}
             />
         </fieldset>
     );
@@ -329,6 +336,7 @@ type AnswersGroupProp = {
     answers: AnswerType[];
     selectedAnswer: string | undefined;
     setSelectedAnswers: (selectedAnswerId: string) => void;
+    theme: Theme;
 };
 
 const AnswersGroup = memo(
@@ -338,10 +346,11 @@ const AnswersGroup = memo(
         answers,
         selectedAnswer,
         setSelectedAnswers,
+        theme,
     }: AnswersGroupProp) => (
         <div
             css={[
-                radioButtonWrapperStyles,
+                radioButtonWrapperStyles(theme),
                 css`
                     label {
                         :hover {


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Updates quiz atom fonts, namely:
- For knowledge quizzes, the (non-revealed) answers are now also using a serif font (they were accidentally using sans, via source's default)
- For both knowledge and personality quizzes, we update the question and answer font choice to be text sans for labs content