### PR TITLE
Update font-face urls to `assets.guim` domain

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -161,11 +161,11 @@
 
     @font-face {
         font-family: 'GH Guardian Headline';
-        src: url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Light.woff2')
+        src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.woff2')
                 format('woff2'),
-            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Light.woff')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.woff')
                 format('woff'),
-            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Light.ttf')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.ttf')
                 format('truetype');
         font-weight: 300;
         font-style: normal;
@@ -173,11 +173,11 @@
 
     @font-face {
         font-family: 'GH Guardian Headline';
-        src: url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-LightItalic.woff2')
+        src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-LightItalic.woff2')
                 format('woff2'),
-            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-LightItalic.woff')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-LightItalic.woff')
                 format('woff'),
-            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-LightItalic.ttf')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-LightItalic.ttf')
                 format('truetype');
         font-weight: 300;
         font-style: italic;
@@ -185,11 +185,11 @@
 
     @font-face {
         font-family: 'GH Guardian Headline';
-        src: url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Regular.woff2')
+        src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Regular.woff2')
                 format('woff2'),
-            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Regular.woff')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Regular.woff')
                 format('woff'),
-            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Regular.ttf')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Regular.ttf')
                 format('truetype');
         font-weight: 400;
         font-style: normal;
@@ -197,11 +197,11 @@
 
     @font-face {
         font-family: 'GH Guardian Headline';
-        src: url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-RegularItalic.woff2')
+        src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-RegularItalic.woff2')
                 format('woff2'),
-            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-RegularItalic.woff')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-RegularItalic.woff')
                 format('woff'),
-            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-RegularItalic.ttf')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-RegularItalic.ttf')
                 format('truetype');
         font-weight: 400;
         font-style: italic;
@@ -209,11 +209,11 @@
 
     @font-face {
         font-family: 'GH Guardian Headline';
-        src: url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Medium.woff2')
+        src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff2')
                 format('woff2'),
-            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Medium.woff')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.woff')
                 format('woff'),
-            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Medium.ttf')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Medium.ttf')
                 format('truetype');
         font-weight: 500;
         font-style: normal;
@@ -221,11 +221,11 @@
 
     @font-face {
         font-family: 'GH Guardian Headline';
-        src: url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-MediumItalic.woff2')
+        src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.woff2')
                 format('woff2'),
-            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-MediumItalic.woff')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.woff')
                 format('woff'),
-            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-MediumItalic.ttf')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-MediumItalic.ttf')
                 format('truetype');
         font-weight: 500;
         font-style: italic;
@@ -233,11 +233,11 @@
 
     @font-face {
         font-family: 'GH Guardian Headline';
-        src: url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Semibold.woff2')
+        src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Semibold.woff2')
                 format('woff2'),
-            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Semibold.woff')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Semibold.woff')
                 format('woff'),
-            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Semibold.ttf')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Semibold.ttf')
                 format('truetype');
         font-weight: 600;
         font-style: normal;
@@ -245,11 +245,11 @@
 
     @font-face {
         font-family: 'GH Guardian Headline';
-        src: url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-SemiboldItalic.woff2')
+        src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-SemiboldItalic.woff2')
                 format('woff2'),
-            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-SemiboldItalic.woff')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-SemiboldItalic.woff')
                 format('woff'),
-            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-SemiboldItalic.ttf')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-SemiboldItalic.ttf')
                 format('truetype');
         font-weight: 600;
         font-style: italic;
@@ -257,11 +257,11 @@
 
     @font-face {
         font-family: 'GH Guardian Headline';
-        src: url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Bold.woff2')
+        src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff2')
                 format('woff2'),
-            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Bold.woff')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff')
                 format('woff'),
-            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Bold.ttf')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.ttf')
                 format('truetype');
         font-weight: 700;
         font-style: normal;
@@ -269,11 +269,11 @@
 
     @font-face {
         font-family: 'GH Guardian Headline';
-        src: url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-BoldItalic.woff2')
+        src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BoldItalic.woff2')
                 format('woff2'),
-            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-BoldItalic.woff')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BoldItalic.woff')
                 format('woff'),
-            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-BoldItalic.ttf')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BoldItalic.ttf')
                 format('truetype');
         font-weight: 700;
         font-style: italic;
@@ -281,11 +281,11 @@
 
     @font-face {
         font-family: 'GH Guardian Headline';
-        src: url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Black.woff2')
+        src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Black.woff2')
                 format('woff2'),
-            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Black.woff')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Black.woff')
                 format('woff'),
-            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Black.ttf')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Black.ttf')
                 format('truetype');
         font-weight: 900;
         font-style: normal;
@@ -293,11 +293,11 @@
 
     @font-face {
         font-family: 'GH Guardian Headline';
-        src: url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-BlackItalic.woff2')
+        src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BlackItalic.woff2')
                 format('woff2'),
-            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-BlackItalic.woff')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BlackItalic.woff')
                 format('woff'),
-            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-BlackItalic.ttf')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-BlackItalic.ttf')
                 format('truetype');
         font-weight: 900;
         font-style: italic;
@@ -307,11 +307,11 @@
 
     @font-face {
         font-family: 'GuardianTextSans';
-        src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Regular.woff2')
+        src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff2')
                 format('woff2'),
-            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Regular.woff')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff')
                 format('woff'),
-            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Regular.ttf')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.ttf')
                 format('truetype');
         font-weight: 400;
         font-style: normal;
@@ -319,11 +319,11 @@
 
     @font-face {
         font-family: 'GuardianTextSans';
-        src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-RegularItalic.woff2')
+        src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-RegularItalic.woff2')
                 format('woff2'),
-            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-RegularItalic.woff')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-RegularItalic.woff')
                 format('woff'),
-            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-RegularItalic.ttf')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-RegularItalic.ttf')
                 format('truetype');
         font-weight: 400;
         font-style: italic;
@@ -331,11 +331,11 @@
 
     @font-face {
         font-family: 'GuardianTextSans';
-        src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Medium.woff2')
+        src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Medium.woff2')
                 format('woff2'),
-            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Medium.woff')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Medium.woff')
                 format('woff'),
-            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Medium.ttf')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Medium.ttf')
                 format('truetype');
         font-weight: 500;
         font-style: normal;
@@ -343,11 +343,11 @@
 
     @font-face {
         font-family: 'GuardianTextSans';
-        src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-MediumItalic.woff2')
+        src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-MediumItalic.woff2')
                 format('woff2'),
-            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-MediumItalic.woff')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-MediumItalic.woff')
                 format('woff'),
-            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-MediumItalic.ttf')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-MediumItalic.ttf')
                 format('truetype');
         font-weight: 500;
         font-style: italic;
@@ -355,11 +355,11 @@
 
     @font-face {
         font-family: 'GuardianTextSans';
-        src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Bold.woff2')
+        src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.woff2')
                 format('woff2'),
-            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Bold.woff')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.woff')
                 format('woff'),
-            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Bold.ttf')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Bold.ttf')
                 format('truetype');
         font-weight: 700;
         font-style: normal;
@@ -367,11 +367,11 @@
 
     @font-face {
         font-family: 'GuardianTextSans';
-        src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-BoldItalic.woff2')
+        src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BoldItalic.woff2')
                 format('woff2'),
-            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-BoldItalic.woff')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BoldItalic.woff')
                 format('woff'),
-            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-BoldItalic.ttf')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BoldItalic.ttf')
                 format('truetype');
         font-weight: 700;
         font-style: italic;
@@ -379,11 +379,11 @@
 
     @font-face {
         font-family: 'GuardianTextSans';
-        src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Black.woff2')
+        src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Black.woff2')
                 format('woff2'),
-            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Black.woff')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Black.woff')
                 format('woff'),
-            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-Black.ttf')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Black.ttf')
                 format('truetype');
         font-weight: 900;
         font-style: normal;
@@ -391,11 +391,11 @@
 
     @font-face {
         font-family: 'GuardianTextSans';
-        src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-BlackItalic.woff2')
+        src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BlackItalic.woff2')
                 format('woff2'),
-            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-BlackItalic.woff')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BlackItalic.woff')
                 format('woff'),
-            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textsans/GuardianTextSans-BlackItalic.ttf')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-BlackItalic.ttf')
                 format('truetype');
         font-weight: 900;
         font-style: italic;
@@ -405,11 +405,11 @@
 
     @font-face {
         font-family: 'GuardianTextEgyptian';
-        src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Regular.woff2')
+        src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff2')
                 format('woff2'),
-            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Regular.woff')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff')
                 format('woff'),
-            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Regular.ttf')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.ttf')
                 format('truetype');
         font-weight: 400;
         font-style: normal;
@@ -417,11 +417,11 @@
 
     @font-face {
         font-family: 'GuardianTextEgyptian';
-        src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-RegularItalic.woff2')
+        src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.woff2')
                 format('woff2'),
-            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-RegularItalic.woff')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.woff')
                 format('woff'),
-            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-RegularItalic.ttf')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.ttf')
                 format('truetype');
         font-weight: 400;
         font-style: italic;
@@ -429,11 +429,11 @@
 
     @font-face {
         font-family: 'GuardianTextEgyptian';
-        src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Medium.woff2')
+        src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Medium.woff2')
                 format('woff2'),
-            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Medium.woff')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Medium.woff')
                 format('woff'),
-            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Medium.ttf')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Medium.ttf')
                 format('truetype');
         font-weight: 500;
         font-style: normal;
@@ -441,11 +441,11 @@
 
     @font-face {
         font-family: 'GuardianTextEgyptian';
-        src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-MediumItalic.woff2')
+        src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-MediumItalic.woff2')
                 format('woff2'),
-            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-MediumItalic.woff')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-MediumItalic.woff')
                 format('woff'),
-            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-MediumItalic.ttf')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-MediumItalic.ttf')
                 format('truetype');
         font-weight: 500;
         font-style: italic;
@@ -453,11 +453,11 @@
 
     @font-face {
         font-family: 'GuardianTextEgyptian';
-        src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Bold.woff2')
+        src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.woff2')
                 format('woff2'),
-            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Bold.woff')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.woff')
                 format('woff'),
-            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Bold.ttf')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.ttf')
                 format('truetype');
         font-weight: 700;
         font-style: normal;
@@ -465,11 +465,11 @@
 
     @font-face {
         font-family: 'GuardianTextEgyptian';
-        src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-BoldItalic.woff2')
+        src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.woff2')
                 format('woff2'),
-            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-BoldItalic.woff')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.woff')
                 format('woff'),
-            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-BoldItalic.ttf')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BoldItalic.ttf')
                 format('truetype');
         font-weight: 700;
         font-style: italic;
@@ -477,11 +477,11 @@
 
     @font-face {
         font-family: 'GuardianTextEgyptian';
-        src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Black.woff2')
+        src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Black.woff2')
                 format('woff2'),
-            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Black.woff')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Black.woff')
                 format('woff'),
-            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Black.ttf')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Black.ttf')
                 format('truetype');
         font-weight: 900;
         font-style: normal;
@@ -489,11 +489,11 @@
 
     @font-face {
         font-family: 'GuardianTextEgyptian';
-        src: url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-BlackItalic.woff2')
+        src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BlackItalic.woff2')
                 format('woff2'),
-            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-BlackItalic.woff')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BlackItalic.woff')
                 format('woff'),
-            url('https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-BlackItalic.ttf')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-BlackItalic.ttf')
                 format('truetype');
         font-weight: 900;
         font-style: italic;
@@ -503,11 +503,11 @@
 
     @font-face {
         font-family: 'GT Guardian Titlepiece';
-        src: url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GTGuardianTitlepiece-Bold.woff2')
+        src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-titlepiece/noalts-not-hinted/GTGuardianTitlepiece-Bold.woff2')
                 format('woff2'),
-            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GTGuardianTitlepiece-Bold.woff')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-titlepiece/noalts-not-hinted/GTGuardianTitlepiece-Bold.woff')
                 format('woff'),
-            url('https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GTGuardianTitlepiece-Bold.ttf')
+            url('https://assets.guim.co.uk/static/frontend/fonts/guardian-titlepiece/noalts-not-hinted/GTGuardianTitlepiece-Bold.ttf')
                 format('truetype');
         font-weight: 700;
         font-style: normal;


### PR DESCRIPTION
## What does this change?

This PR updates the `font-face` tags in `.storybook/preview-head.html` to load the fonts from the `assets.guim` domain as specified in https://github.com/guardian/fonts

## How to test

Run storybook and verify that components still render correctly

## How can we measure success?

Fonts are loaded from the recommended location