### PR TITLE
`react-dom` Over `preact-render-to-string`

### DIFF
--- a/src/lib/unifyPageContent.tsx
+++ b/src/lib/unifyPageContent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import render from 'preact-render-to-string';
+import { renderToString } from 'react-dom/server';
 
 export const unifyPageContent = ({
     elementCss,
@@ -10,7 +10,7 @@ export const unifyPageContent = ({
     elementJs: string;
     elementHtml?: string;
 }): string =>
-    render(
+    renderToString(
         <html>
             <head>
                 <meta charSet="utf-8" />


### PR DESCRIPTION
## What does this change?

This switches from using `preact-render-to-string` to `react-dom/server` for the `renderToString` function.

We use a mix of React and Preact across the department, and [common](https://github.com/guardian/dotcom-rendering/blob/14779a173d9f19af8dbab456749f1421d5a372fd/scripts/webpack/frontend.js#L29) [practice](https://github.com/guardian/support-frontend/blob/4048812d6f0c572ba1803c0f3b3d7d78fa3823dd/support-frontend/webpack.common.js#L97) in Preact codebases is to treat React as the default and alias to `preact-compat`. Therefore I think it's best to also treat React as the default in our libraries, and let the consumers decide whether they want to alias that to Preact.

This will also mean that we can remove an [awkward workaround](https://github.com/guardian/apps-rendering/blob/94b2640fe9c8afcb3e1c05448b09e7f164ec64bc/webpack.config.ts#L59) in Apps-Rendering, where we've tried to alias in the other direction in order to accommodate atoms-rendering. Unfortunately this workaround has started to [cause us problems](https://github.com/guardian/apps-rendering/pull/1401) and we think that updating atoms-rendering to conform to the React API may solve this.

## How to test

Checks on this PR pass and atoms continue to work in DCR and AR.

## How can we measure success?

The webpack upgrade on AR becomes unblocked.

## Have we considered potential risks?

Possibility of changes being required in DCR, although given that DCR already aliases `react-dom` to Preact it _should_ work fine.
