### PR TITLE
update InteractiveAtomType interface to allow undefined elementJs

### DIFF
--- a/src/InteractiveAtom.tsx
+++ b/src/InteractiveAtom.tsx
@@ -18,7 +18,7 @@ type InteractiveAtomType = {
     id: string;
     elementUrl?: string;
     elementHtml?: string;
-    elementJs: string;
+    elementJs?: string;
     elementCss?: string;
     isMainMedia?: boolean;
 };

--- a/src/lib/unifyPageContent.test.tsx
+++ b/src/lib/unifyPageContent.test.tsx
@@ -35,4 +35,12 @@ describe('unifyPageContent', () => {
         });
         expect(outputHTML).not.toContain(`<div`);
     });
+
+    it('should render successfully when no elementJs', () => {
+        const outputHTML = unifyPageContent({
+            elementCss,
+            elementHtml,
+        });
+        expect(outputHTML).not.toContain(elementJs);
+    });
 });

--- a/src/lib/unifyPageContent.tsx
+++ b/src/lib/unifyPageContent.tsx
@@ -7,7 +7,7 @@ export const unifyPageContent = ({
     elementHtml,
 }: {
     elementCss?: string;
-    elementJs: string;
+    elementJs?: string;
     elementHtml?: string;
 }): string =>
     render(
@@ -28,7 +28,9 @@ export const unifyPageContent = ({
                 )}
             </body>
             {/* JS need to load on body render */}
-            <script dangerouslySetInnerHTML={{ __html: elementJs }} />
+            {elementJs && (
+                <script dangerouslySetInnerHTML={{ __html: elementJs }} />
+            )}
             <script
                 dangerouslySetInnerHTML={{
                     __html: `


### PR DESCRIPTION
## What does this change?
Some legacy interactive atoms do not contain any js in the element object returned from capi. When loading the interactive via dcr this results in a schema error, see https://github.com/guardian/dotcom-rendering/pull/3204. However, to rectify this issue atoms-rendering requires an update to the type interface. This PR relaxes the interactive atom type by making property elementJs type string or undefined.

## How to test
Along with deployment of associated dcr changes, legacy interactive atoms load successfully, eg https://www.theguardian.com/us-news/ng-interactive/2017/jan/26/obamacare-what-next-healthcare-preexisting-conditions?dcr. 

## How can we measure success?
After deployment, along with https://github.com/guardian/dotcom-rendering/pull/3204, legacy interactive atoms successfully render via dcr.

## Have we considered potential risks?
Risk is low as the change is small. Local testing shows current + legacy interactive atoms loading correctly. I've captured the change in the tests too.

