### PR TITLE
YoutubeAtom should respect adfree users

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ An example PR for adding the Profile Atom can be found [here](https://github.com
 
 ## Releasing a new version / Publishing to NPM
 
-Pre-requisits:
+Prerequisites:
 
 1. Ensure your changes are on main
 2. Ensure you have an [npm account](https://docs.npmjs.com/creating-and-publishing-scoped-public-packages) that is authorised for the npm @guardian organisation

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -38,34 +38,49 @@ declare global {
 type YoutubeStateChangeEventType = { data: -1 | 0 | 1 | 2 | 3 | 5 };
 
 type EmbedConfig = {
-    adsConfig: {
-        adTagParameters: {
-            iu: string;
-            cust_params: string;
-        };
-    };
+    adsConfig:
+        | {
+              adTagParameters: {
+                  iu: string;
+                  cust_params: string;
+              };
+              disableAds?: false;
+          }
+        | {
+              disableAds: true;
+          };
 };
 
 const buildEmbedConfig = (adTargeting: AdTargetingType): EmbedConfig => {
-    return {
-        adsConfig: {
-            adTagParameters: {
-                iu: `${adTargeting.adUnit || ''}`,
-                cust_params: encodeURIComponent(
-                    constructQuery(adTargeting.customParams),
-                ),
-            },
-        },
-    };
+    switch (adTargeting.disableAds) {
+        case true:
+            return {
+                adsConfig: {
+                    disableAds: true,
+                },
+            };
+        case false:
+        case undefined:
+            return {
+                adsConfig: {
+                    adTagParameters: {
+                        iu: `${adTargeting.adUnit || ''}`,
+                        cust_params: encodeURIComponent(
+                            constructQuery(adTargeting.customParams || {}),
+                        ),
+                    },
+                },
+            };
+    }
 };
 
-const constructQuery = (query: { [key: string]: string }): string =>
+const constructQuery = (query: { [key: string]: unknown }): string =>
     Object.keys(query)
         .map((param: string) => {
             const value = query[param];
             const queryValue = Array.isArray(value)
                 ? value.map((v) => encodeURIComponent(v)).join(',')
-                : encodeURIComponent(value);
+                : encodeURIComponent(String(value));
             return `${param}=${queryValue}`;
         })
         .join('&');

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,14 @@
 import { Theme } from '@guardian/types';
 
-export type AdTargetingType = {
-    adUnit: string;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    customParams: { [key: string]: any };
-};
+export type AdTargetingType =
+    | {
+          adUnit: string;
+          customParams: Record<string, unknown>;
+          disableAds?: false;
+      }
+    | {
+          disableAds: true;
+      };
 
 export type AudioAtomType = {
     id: string;


### PR DESCRIPTION
## What does this change?

Amend `YoutubeAtom` to accept `adsConfig: { disableAds: true }` as a flag to pass to the YouTube player.

Follows method in Frontend [youtube-player](https://github.com/guardian/frontend/blob/df31b4deeb7f72303ebfa766f6a2699e2be1a293/static/src/javascripts/projects/common/modules/atoms/youtube-player.ts#L171)

## How to test

1. Log in as a subscribed user
2. Checking a DCR rendered video page such as [this one](https://www.theguardian.com/science/2021/jul/20/jeff-bezos-rocket-design-an-inquiry). It should not show an ad before the video

## Dependencies

DCR PR https://github.com/guardian/dotcom-rendering/pull/3225 is dependent on this change.