### PR TITLE
Temporary fix for Knowledge quizzes

### DIFF
--- a/src/KnowledgeQuiz.tsx
+++ b/src/KnowledgeQuiz.tsx
@@ -376,7 +376,6 @@ export const Result = ({
                 <span
                     css={resultsNumberStyles}
                 >{`${numberOfCorrectAnswers}/${totalNumberOfQuestions}`}</span>
-                {bestResultGroup && <span>{bestResultGroup.title}</span>}
             </div>
 
             <hr />


### PR DESCRIPTION
## What does this change?
This is a temporary fix while the root problem is found for knowledge type quizzes to display the wrong message. 

For now these messages have been turned off until the solution is found.

## Before
![Screenshot 2021-09-06 at 12 21 23](https://user-images.githubusercontent.com/35331926/132211449-63ccef33-71c0-4551-88bf-866d991c107f.png)

## After
![Screenshot 2021-09-06 at 12 22 00](https://user-images.githubusercontent.com/35331926/132211466-b01568ff-cce6-4c38-ad0d-570a9d387e43.png)

