### PR TITLE
Remove unused preact. Fixes DCR yarn linking

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,6 @@
         "jest": "^26.6.3",
         "jest-environment-jsdom-sixteen": "^1.0.3",
         "np": "^7.2.0",
-        "preact": "^10.5.7",
-        "preact-render-to-string": "^5.1.12",
         "prettier": "^2.1.2",
         "pretty-quick": "^3.1.0",
         "react": "^17.0.1",
@@ -108,8 +106,6 @@
         "@guardian/src-icons": "^3.7.0",
         "@guardian/src-radio": "^3.6.0",
         "@guardian/types": "^5.1.0",
-        "preact": "^10.5.7",
-        "preact-render-to-string": "^5.1.12",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
         "typescript": "^4.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10681,18 +10681,6 @@ postcss@^7.0.32:
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-preact-render-to-string@^5.1.12:
-  version "5.1.12"
-  resolved "https://registry.yarnpkg.com/preact-render-to-string/-/preact-render-to-string-5.1.12.tgz#3d258a177ef8947f768dd0f2c56629e7fda2dc39"
-  integrity sha512-nXVCOpvepSk9AfPwqS08rf9NDOCs8eeYYlG+7tE85iP5jVyjz+aYb1BYaP5SPdfVWVrzI9L5NzxozUvKaD96tA==
-  dependencies:
-    pretty-format "^3.8.0"
-
-preact@^10.5.7:
-  version "10.5.7"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.7.tgz#f1d84725539e18f7ccbea937cf3db5895661dbd3"
-  integrity sha512-4oEpz75t/0UNcwmcsjk+BIcDdk68oao+7kxcpc1hQPNs2Oo3ZL9xFz8UBf350mxk/VEdD41L5b4l2dE3Ug3RYg==
-
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -10742,11 +10730,6 @@ pretty-format@^26.0.0, pretty-format@^26.6.2:
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
-
-pretty-format@^3.8.0:
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-3.8.0.tgz#bfbed56d5e9a776645f4b1ff7aa1a3ac4fa3c385"
-  integrity sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U=
 
 pretty-hrtime@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
## What does this change?

Removes Preact as it is no longer used.

This has the happy side effect of fixing yarn linking issues in DCR as explained below.

## TL;DR

1. This previous [workaround](https://github.com/guardian/atoms-rendering/pull/143) meant `preact-render-to-string` was introduced to `atoms-rendering`
1. Because `preact-render-to-string` was introduced to `atoms-rendering` any React app that transpiled `atoms-rendering` had to implement a (reverse) webpack alias:
    `'preact-render-to-string': 'react-dom/server'`
1. Because `preact` was added to `atoms-rendering` when yarn/npm linking to a consuming app that also had `preact` (e.g. DCR) runtime exceptions would be thrown because of known artifacts with yarn/npm linking.

Given there is a fix for 1. and `preact` has been removed from `atoms-rendering`, we can now remove all of the workarounds, aliasing and fix yarn linking.

## Detail

### Issues

We have the following related issues:

1. **Module not found Error**
Back in Nov 2020 compiling DCR would result in the following error:
`Module not found: Error: Package path ./compat/server is not exported`
A workaround resulted in adding `preact-render-to-string` to `atoms-rendering` as explained in [this PR](https://github.com/guardian/atoms-rendering/pull/143).
1. **Webpack aliasing**
Due to 1. any React app consumer of `atoms-rendering` had to implement a webpack alias:
    `'preact-render-to-string': 'react-dom/server'` such as ([link](https://github.com/guardian/dotcom-rendering/blob/33b89cfcf321fb999880f38419f6353a55a2e05b/apps-rendering/webpack.config.ts#L59), [link](https://github.com/guardian/dotcom-rendering/blob/d69152d08f86d7a22aa12b9df8a417588c520438/apps-rendering/config/jest.config.js#L54), [link](https://github.com/guardian/dotcom-rendering/blob/98486a70fbe147e9c51577f11a48a64d202adf6a/.storybook/main.js#L156))
1. **Yarn linking x-rendering projects**
Due to 1. and **known artifacts of yarn/npm symlinking** ([link](https://blog.maximeheckel.com/posts/duplicate-dependencies-npm-link), [link](https://github.com/yarnpkg/yarn/issues/8105)) when locally linking `atoms-rendering` to `dotcom-rendering` (for example) linked **components hooks** would throw the runtime exception:
`Uncaught (in promise) TypeError: Cannot read property '__H' of undefined` 

    What is happening is that the symlinked repo would resolve dependencies to its own dependencies (either actual or dev) rather than those of the consuming app, creating multiple instances.

    Packages such as React, Preact and emotion however require a single context i.e. all 'react' dependencies should resolve to the same module ([link](https://reactjs.org/warnings/invalid-hook-call-warning.html#duplicate-react), [link](https://github.com/facebook/react/issues/13991)).

    The result was when linking repositories locally, linked components (e.g. `YoutubeAtom`) did not work.
An adhoc fix (not applied but fyi) would be to force the consuming app to make React, Preact etc to resolve to its _own_ `node_modules` e.g. : 
    ```js
    // ... App Webpack config ...
    resolve: {
      alias: {
        react: path.resolve('./node_modules/react'),
        @emotion/core: path.resolve('./node_modules/@emotion/core')
    }
    ```
    (** this maybe fixed in Yarn 2 - TODO investigate)
### Fixes

1. **Module not found Error**

    The root cause of this is a bug in the exported files of the Preact project :
     https://github.com/preactjs/preact/issues/1329 
    
    This first stable release to include this was preact@10.0.0 :
    https://github.com/preactjs/preact/pull/1332
    It was fixed _again_ for Webpack 5 in preact@10.5.8 :
    https://github.com/preactjs/preact/pull/2873
    
    DCR has got this Preact fix via its semver but upgrading will make this explicit.

2. **Webpack aliasing**

    A recent `atoms-rendering` [PR](https://github.com/guardian/atoms-rendering/pull/270) removed `preact-render-to-string` and instead forces the consuming application to alias `react-dom/server` if required.

    Because of fixes 1. and 2. we can now remove all webpack aliases.

3. **Yarn linking x-rendering projects**
Because of fixes 1. and 2. we can simply remove Preact from `atoms-rendering` so there is no duplicate module resolution when linking locally and linked components function as expected.


