### PR TITLE
fix: Only apply `height: 100%` to interactive main media when `Immersive`

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
         "react-dom": "^17.0.1",
         "ts-jest": "^24.3.0",
         "ts-loader": "^8.0.18",
-        "typescript": "^4.1.3"
+        "typescript": "^4.1.3",
+        "web-vitals": "^2.1.2"
     },
     "eslintConfig": {
         "root": true,

--- a/package.json
+++ b/package.json
@@ -108,7 +108,8 @@
         "@guardian/source-react-components": "^4.0.0-rc.1",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
-        "typescript": "^4.1.3"
+        "typescript": "^4.1.3",
+        "web-vitals": "^2.1.2"
     },
     "jest": {
         "testEnvironment": "jest-environment-jsdom-sixteen",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "@guardian/commercial-core": "^0.26.0",
         "@guardian/consent-management-platform": "^8",
         "@guardian/eslint-plugin-source-react-components": "^4.0.0-rc.1",
-        "@guardian/libs": "^3.1.0",
+        "@guardian/libs": "^3.5.1",
         "@guardian/source-foundations": "^4.0.0-rc.0",
         "@guardian/source-react-components": "^4.0.0-rc.1",
         "@storybook/addon-docs": "^6.1.11",
@@ -104,7 +104,6 @@
     "peerDependencies": {
         "@emotion/react": "^11.1.5",
         "@guardian/consent-management-platform": "^8",
-        "@guardian/libs": "^3.1.0",
         "@guardian/source-foundations": "^4.0.0-rc.0",
         "@guardian/source-react-components": "^4.0.0-rc.1",
         "react": "^17.0.1",

--- a/src/InteractiveAtom.stories.tsx
+++ b/src/InteractiveAtom.stories.tsx
@@ -6,6 +6,7 @@ import {
     MainMedia,
 } from './fixtures/InteractiveAtomBlockElement';
 import { InteractiveAtom } from './InteractiveAtom';
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from '@guardian/libs';
 
 export default {
     title: 'InteractiveAtom',
@@ -26,6 +27,11 @@ export const DefaultStory = (): JSX.Element => {
                 elementHtml={html}
                 elementJs={js}
                 elementCss={atomCss}
+                format={{
+                    display: ArticleDisplay.Standard,
+                    design: ArticleDesign.Standard,
+                    theme: ArticlePillar.News,
+                }}
             />
         </div>
     );
@@ -35,7 +41,7 @@ DefaultStory.parameters = {
     chromatic: { disable: true },
 };
 
-export const MainMediaStory = (): JSX.Element => {
+export const ImmersiveMainMediaStory = (): JSX.Element => {
     const { id, html, js, css: atomCss } = MainMedia;
     return (
         <div
@@ -50,11 +56,16 @@ export const MainMediaStory = (): JSX.Element => {
                 elementJs={js}
                 elementCss={atomCss}
                 isMainMedia={true}
+                format={{
+                    display: ArticleDisplay.Immersive,
+                    design: ArticleDesign.Standard,
+                    theme: ArticlePillar.News,
+                }}
             />
         </div>
     );
 };
-MainMedia.parameters = {
+ImmersiveMainMediaStory.parameters = {
     // This interactive uses animation which is causing false negatives for Chromatic
     chromatic: { disable: true },
 };

--- a/src/InteractiveAtom.tsx
+++ b/src/InteractiveAtom.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { css } from '@emotion/react';
 
 import { unifyPageContent } from './lib/unifyPageContent';
+import { ArticleDisplay, ArticleFormat } from '@guardian/libs';
 
 const containerStyles = css`
     margin: 0;
@@ -21,6 +22,7 @@ type InteractiveAtomType = {
     elementJs?: string;
     elementCss?: string;
     isMainMedia?: boolean;
+    format: ArticleFormat;
 };
 
 export const InteractiveAtom = ({
@@ -29,6 +31,7 @@ export const InteractiveAtom = ({
     elementJs,
     elementCss,
     isMainMedia,
+    format,
 }: InteractiveAtomType): JSX.Element => (
     <div
         css={[containerStyles, isMainMedia && fullHeightStyles]}
@@ -36,7 +39,12 @@ export const InteractiveAtom = ({
         data-atom-type="interactive"
     >
         <iframe
-            css={[fullWidthStyles, isMainMedia && fullHeightStyles]}
+            css={[
+                fullWidthStyles,
+                isMainMedia &&
+                    format.display === ArticleDisplay.Immersive &&
+                    fullHeightStyles,
+            ]}
             srcDoc={unifyPageContent({ elementJs, elementCss, elementHtml })}
             frameBorder="0"
         />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1489,10 +1489,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-3.3.0.tgz#fa98c7b8216ab35b8cf3087cd9ba336958fac99a"
   integrity sha512-XB9o8qtDOg+KlPh1sjEr4u+Ai3RFTRr2riZ/HJpdlh8Cu4ZpYjCSGUZXSGkxp1CwFWT9sduANnsWSqZ97iBloQ==
 
-"@guardian/libs@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-3.1.0.tgz#44b0291741a0fce588167f4ec8c17fa9a7d41261"
-  integrity sha512-GJk34o9lUmP6FcBKd0FSV2RwvAKKJzcAV5mVdhgq/JmBNj8Ns5eiJlq8LG2ewIJJSzRaWT4h8Fg6n9KI8K0xDQ==
+"@guardian/libs@^3.5.1":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-3.5.1.tgz#069fb9140f77d88cc68d476da9c626c18b9ed883"
+  integrity sha512-obu0aPfkbe6kdo18e0dEq/esVjAhwZpQusU/yRjDQFBQMcG4CvPtD0HZb6sI1Grm2NWdBueHHQcJ0YX48SDCsg==
 
 "@guardian/source-foundations@^4.0.0-rc.0":
   version "4.0.0-rc.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13916,6 +13916,11 @@ web-namespaces@^1.0.0:
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-1.1.4.tgz#bc98a3de60dadd7faefc403d1076d529f5e030ec"
   integrity sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==
 
+web-vitals@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-2.1.2.tgz#3a6c8faebf9097a6ccd17f5f45c9485d8d62dab1"
+  integrity sha512-nZnEH8dj+vJFqCRYdvYv0a59iLXsb8jJkt+xvXfwgnkyPdsSLtKNlYmtTDiHmTNGXeSXtpjTTUcNvFtrAk6VMQ==
+
 webidl-conversions@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"


### PR DESCRIPTION
## What does this change?
This extends the work done in [this PR](https://github.com/guardian/atoms-rendering/pull/243 ) by @liywjl to limit that fix to only apply to immersive articles.

## Why?
The 100% height fix is still needed to prevent the iframe resize from being constrained by its container and ending up choosing a height of 150px - which was the old problem. But on liveblogs the same fix has the opposite effect.

There's an argument at this point that we could review the various containers we are rendering main media in different contexts. Perhaps there's a way to rationalise things to remove the need for this and the original work. I did go down this route, it wasn't as simple as I wanted and I felt that I was starting to introduce more risk and complexity that the situation justified. Instead, by passing in `format` and using that to limit the original fix the issue is resolved.

### Before
<img width="872" alt="Screenshot 2021-11-24 at 17 04 02" src="https://user-images.githubusercontent.com/1336821/143283095-094545c5-e954-4ee3-a634-d4036869e987.png">


### After
<img width="872" alt="Screenshot 2021-11-24 at 17 00 03" src="https://user-images.githubusercontent.com/1336821/143282629-5f8d481b-11a6-47ff-a3b6-414ec6bd7e21.png">

## Test articles used (for future me)
Standard: https://www.theguardian.com/cities/2017/feb/13/tipping-point-cities-exercise-more-harm-than-good
Liveblog: https://www.theguardian.com/australia-news/live/2021/nov/17/australia-news-live-nt-covid-corona-katherine-victoria-nsw-pandemic-legislation-protesters-flooding-forbes
Immersive: https://www.theguardian.com/science/grrlscientist/2012/aug/07/3*

*I used Mystery Bird here because I couldn't find any immersive articles with interactive main media. Chances are this will have been removed by the time any future us' are reading this. But if you need to do the same trick just delete the mystery bird main media in Composer and then paste [this url](https://api.nextgen.guardianapps.co.uk/embed/atom/interactive/interactives%2F2018%2F06%2Fbriefing-bubbles) in the input field (where it says paste embed code).

## Merci
Thank you @liywjl for helping me with my code archeology on this one 🙏 