### PR TITLE
Optional tracking handlers

### DIFF
--- a/src/GuideAtom.tsx
+++ b/src/GuideAtom.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { GuideAtomType } from './types';
+import { submitComponentEvent } from './lib/ophan';
 import { Footer } from './expandableAtom/Footer';
 import { Container } from './expandableAtom/Container';
 import { Body } from './expandableAtom/Body';
@@ -25,13 +26,43 @@ export const GuideAtom = ({
             atomType="guide"
             atomTypeTitle="Quick Guide"
             expandForStorybook={expandForStorybook}
-            expandCallback={expandCallback}
+            expandCallback={() =>
+                submitComponentEvent({
+                    component: {
+                        componentType: 'GUIDE_ATOM',
+                        id,
+                        products: [],
+                        labels: [],
+                    },
+                    action: 'EXPAND',
+                })
+            }
         >
             <Body html={html} image={image} credit={credit} pillar={pillar} />
             <Footer
                 pillar={pillar}
-                dislikeHandler={dislikeHandler}
-                likeHandler={likeHandler}
+                dislikeHandler={() =>
+                    submitComponentEvent({
+                        component: {
+                            componentType: 'GUIDE_ATOM',
+                            id,
+                            products: [],
+                            labels: [],
+                        },
+                        action: 'DISLIKE',
+                    })
+                }
+                likeHandler={() =>
+                    submitComponentEvent({
+                        component: {
+                            componentType: 'GUIDE_ATOM',
+                            id,
+                            products: [],
+                            labels: [],
+                        },
+                        action: 'LIKE',
+                    })
+                }
             ></Footer>
         </Container>
     );

--- a/src/GuideAtom.tsx
+++ b/src/GuideAtom.tsx
@@ -26,42 +26,48 @@ export const GuideAtom = ({
             atomType="guide"
             atomTypeTitle="Quick Guide"
             expandForStorybook={expandForStorybook}
-            expandCallback={() =>
-                submitComponentEvent({
-                    component: {
-                        componentType: 'GUIDE_ATOM',
-                        id,
-                        products: [],
-                        labels: [],
-                    },
-                    action: 'EXPAND',
-                })
+            expandCallback={
+                expandCallback ||
+                (() =>
+                    submitComponentEvent({
+                        component: {
+                            componentType: 'GUIDE_ATOM',
+                            id,
+                            products: [],
+                            labels: [],
+                        },
+                        action: 'EXPAND',
+                    }))
             }
         >
             <Body html={html} image={image} credit={credit} pillar={pillar} />
             <Footer
                 pillar={pillar}
-                dislikeHandler={() =>
-                    submitComponentEvent({
-                        component: {
-                            componentType: 'GUIDE_ATOM',
-                            id,
-                            products: [],
-                            labels: [],
-                        },
-                        action: 'DISLIKE',
-                    })
+                dislikeHandler={
+                    dislikeHandler ||
+                    (() =>
+                        submitComponentEvent({
+                            component: {
+                                componentType: 'GUIDE_ATOM',
+                                id,
+                                products: [],
+                                labels: [],
+                            },
+                            action: 'DISLIKE',
+                        }))
                 }
-                likeHandler={() =>
-                    submitComponentEvent({
-                        component: {
-                            componentType: 'GUIDE_ATOM',
-                            id,
-                            products: [],
-                            labels: [],
-                        },
-                        action: 'LIKE',
-                    })
+                likeHandler={
+                    likeHandler ||
+                    (() =>
+                        submitComponentEvent({
+                            component: {
+                                componentType: 'GUIDE_ATOM',
+                                id,
+                                products: [],
+                                labels: [],
+                            },
+                            action: 'LIKE',
+                        }))
                 }
             ></Footer>
         </Container>

--- a/src/ProfileAtom.tsx
+++ b/src/ProfileAtom.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { ProfileAtomType } from './types';
+import { submitComponentEvent } from './lib/ophan';
 import { Container } from './expandableAtom/Container';
 import { Footer } from './expandableAtom/Footer';
 import { Body } from './expandableAtom/Body';
@@ -25,13 +26,43 @@ export const ProfileAtom = ({
             atomType="profile"
             atomTypeTitle="Profile"
             expandForStorybook={expandForStorybook}
-            expandCallback={expandCallback}
+            expandCallback={() =>
+                submitComponentEvent({
+                    component: {
+                        componentType: 'PROFILE_ATOM',
+                        id,
+                        products: [],
+                        labels: [],
+                    },
+                    action: 'EXPAND',
+                })
+            }
         >
             <Body html={html} image={image} credit={credit} pillar={pillar} />
             <Footer
                 pillar={pillar}
-                dislikeHandler={dislikeHandler}
-                likeHandler={likeHandler}
+                dislikeHandler={() =>
+                    submitComponentEvent({
+                        component: {
+                            componentType: 'PROFILE_ATOM',
+                            id,
+                            products: [],
+                            labels: [],
+                        },
+                        action: 'DISLIKE',
+                    })
+                }
+                likeHandler={() =>
+                    submitComponentEvent({
+                        component: {
+                            componentType: 'PROFILE_ATOM',
+                            id,
+                            products: [],
+                            labels: [],
+                        },
+                        action: 'LIKE',
+                    })
+                }
             ></Footer>
         </Container>
     );

--- a/src/ProfileAtom.tsx
+++ b/src/ProfileAtom.tsx
@@ -26,42 +26,48 @@ export const ProfileAtom = ({
             atomType="profile"
             atomTypeTitle="Profile"
             expandForStorybook={expandForStorybook}
-            expandCallback={() =>
-                submitComponentEvent({
-                    component: {
-                        componentType: 'PROFILE_ATOM',
-                        id,
-                        products: [],
-                        labels: [],
-                    },
-                    action: 'EXPAND',
-                })
+            expandCallback={
+                expandCallback ||
+                (() =>
+                    submitComponentEvent({
+                        component: {
+                            componentType: 'PROFILE_ATOM',
+                            id,
+                            products: [],
+                            labels: [],
+                        },
+                        action: 'EXPAND',
+                    }))
             }
         >
             <Body html={html} image={image} credit={credit} pillar={pillar} />
             <Footer
                 pillar={pillar}
-                dislikeHandler={() =>
-                    submitComponentEvent({
-                        component: {
-                            componentType: 'PROFILE_ATOM',
-                            id,
-                            products: [],
-                            labels: [],
-                        },
-                        action: 'DISLIKE',
-                    })
+                dislikeHandler={
+                    dislikeHandler ||
+                    (() =>
+                        submitComponentEvent({
+                            component: {
+                                componentType: 'PROFILE_ATOM',
+                                id,
+                                products: [],
+                                labels: [],
+                            },
+                            action: 'DISLIKE',
+                        }))
                 }
-                likeHandler={() =>
-                    submitComponentEvent({
-                        component: {
-                            componentType: 'PROFILE_ATOM',
-                            id,
-                            products: [],
-                            labels: [],
-                        },
-                        action: 'LIKE',
-                    })
+                likeHandler={
+                    likeHandler ||
+                    (() =>
+                        submitComponentEvent({
+                            component: {
+                                componentType: 'PROFILE_ATOM',
+                                id,
+                                products: [],
+                                labels: [],
+                            },
+                            action: 'LIKE',
+                        }))
                 }
             ></Footer>
         </Container>

--- a/src/QandaAtom.tsx
+++ b/src/QandaAtom.tsx
@@ -24,42 +24,48 @@ export const QandaAtom = ({
         atomTypeTitle="Q&A"
         pillar={pillar}
         expandForStorybook={expandForStorybook}
-        expandCallback={() =>
-            submitComponentEvent({
-                component: {
-                    componentType: 'QANDA_ATOM',
-                    id,
-                    products: [],
-                    labels: [],
-                },
-                action: 'EXPAND',
-            })
+        expandCallback={
+            expandCallback ||
+            (() =>
+                submitComponentEvent({
+                    component: {
+                        componentType: 'QANDA_ATOM',
+                        id,
+                        products: [],
+                        labels: [],
+                    },
+                    action: 'EXPAND',
+                }))
         }
     >
         <Body html={html} image={image} credit={credit} pillar={pillar} />
         <Footer
             pillar={pillar}
-            dislikeHandler={() =>
-                submitComponentEvent({
-                    component: {
-                        componentType: 'QANDA_ATOM',
-                        id,
-                        products: [],
-                        labels: [],
-                    },
-                    action: 'DISLIKE',
-                })
+            dislikeHandler={
+                dislikeHandler ||
+                (() =>
+                    submitComponentEvent({
+                        component: {
+                            componentType: 'QANDA_ATOM',
+                            id,
+                            products: [],
+                            labels: [],
+                        },
+                        action: 'DISLIKE',
+                    }))
             }
-            likeHandler={() =>
-                submitComponentEvent({
-                    component: {
-                        componentType: 'QANDA_ATOM',
-                        id,
-                        products: [],
-                        labels: [],
-                    },
-                    action: 'LIKE',
-                })
+            likeHandler={
+                likeHandler ||
+                (() =>
+                    submitComponentEvent({
+                        component: {
+                            componentType: 'QANDA_ATOM',
+                            id,
+                            products: [],
+                            labels: [],
+                        },
+                        action: 'LIKE',
+                    }))
             }
         ></Footer>
     </Container>

--- a/src/QandaAtom.tsx
+++ b/src/QandaAtom.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { QandaAtomType } from './types';
+import { submitComponentEvent } from './lib/ophan';
 import { Container } from './expandableAtom/Container';
 import { Footer } from './expandableAtom/Footer';
 import { Body } from './expandableAtom/Body';
@@ -23,13 +24,43 @@ export const QandaAtom = ({
         atomTypeTitle="Q&A"
         pillar={pillar}
         expandForStorybook={expandForStorybook}
-        expandCallback={expandCallback}
+        expandCallback={() =>
+            submitComponentEvent({
+                component: {
+                    componentType: 'QANDA_ATOM',
+                    id,
+                    products: [],
+                    labels: [],
+                },
+                action: 'EXPAND',
+            })
+        }
     >
         <Body html={html} image={image} credit={credit} pillar={pillar} />
         <Footer
             pillar={pillar}
-            likeHandler={likeHandler}
-            dislikeHandler={dislikeHandler}
+            dislikeHandler={() =>
+                submitComponentEvent({
+                    component: {
+                        componentType: 'QANDA_ATOM',
+                        id,
+                        products: [],
+                        labels: [],
+                    },
+                    action: 'DISLIKE',
+                })
+            }
+            likeHandler={() =>
+                submitComponentEvent({
+                    component: {
+                        componentType: 'QANDA_ATOM',
+                        id,
+                        products: [],
+                        labels: [],
+                    },
+                    action: 'LIKE',
+                })
+            }
         ></Footer>
     </Container>
 );

--- a/src/TimelineAtom.tsx
+++ b/src/TimelineAtom.tsx
@@ -126,43 +126,49 @@ export const TimelineAtom = ({
             pillar={pillar}
             expandForStorybook={expandForStorybook}
             title={title}
-            expandCallback={() =>
-                submitComponentEvent({
-                    component: {
-                        componentType: 'TIMELINE_ATOM',
-                        id,
-                        products: [],
-                        labels: [],
-                    },
-                    action: 'EXPAND',
-                })
+            expandCallback={
+                expandCallback ||
+                (() =>
+                    submitComponentEvent({
+                        component: {
+                            componentType: 'TIMELINE_ATOM',
+                            id,
+                            products: [],
+                            labels: [],
+                        },
+                        action: 'EXPAND',
+                    }))
             }
         >
             {description && <Body html={description} pillar={pillar} />}
             {events && <TimelineContents events={events} pillar={pillar} />}
             <Footer
                 pillar={pillar}
-                dislikeHandler={() =>
-                    submitComponentEvent({
-                        component: {
-                            componentType: 'TIMELINE_ATOM',
-                            id,
-                            products: [],
-                            labels: [],
-                        },
-                        action: 'DISLIKE',
-                    })
+                dislikeHandler={
+                    dislikeHandler ||
+                    (() =>
+                        submitComponentEvent({
+                            component: {
+                                componentType: 'TIMELINE_ATOM',
+                                id,
+                                products: [],
+                                labels: [],
+                            },
+                            action: 'DISLIKE',
+                        }))
                 }
-                likeHandler={() =>
-                    submitComponentEvent({
-                        component: {
-                            componentType: 'TIMELINE_ATOM',
-                            id,
-                            products: [],
-                            labels: [],
-                        },
-                        action: 'LIKE',
-                    })
+                likeHandler={
+                    likeHandler ||
+                    (() =>
+                        submitComponentEvent({
+                            component: {
+                                componentType: 'TIMELINE_ATOM',
+                                id,
+                                products: [],
+                                labels: [],
+                            },
+                            action: 'LIKE',
+                        }))
                 }
             />
         </Container>

--- a/src/TimelineAtom.tsx
+++ b/src/TimelineAtom.tsx
@@ -11,6 +11,7 @@ import {
 import { ArticleTheme } from '@guardian/libs';
 
 import { TimelineEvent, TimelineAtomType } from './types';
+import { submitComponentEvent } from './lib/ophan';
 
 import { Container } from './expandableAtom/Container';
 import { Footer } from './expandableAtom/Footer';
@@ -125,14 +126,44 @@ export const TimelineAtom = ({
             pillar={pillar}
             expandForStorybook={expandForStorybook}
             title={title}
-            expandCallback={expandCallback}
+            expandCallback={() =>
+                submitComponentEvent({
+                    component: {
+                        componentType: 'TIMELINE_ATOM',
+                        id,
+                        products: [],
+                        labels: [],
+                    },
+                    action: 'EXPAND',
+                })
+            }
         >
             {description && <Body html={description} pillar={pillar} />}
             {events && <TimelineContents events={events} pillar={pillar} />}
             <Footer
                 pillar={pillar}
-                dislikeHandler={dislikeHandler}
-                likeHandler={likeHandler}
+                dislikeHandler={() =>
+                    submitComponentEvent({
+                        component: {
+                            componentType: 'TIMELINE_ATOM',
+                            id,
+                            products: [],
+                            labels: [],
+                        },
+                        action: 'DISLIKE',
+                    })
+                }
+                likeHandler={() =>
+                    submitComponentEvent({
+                        component: {
+                            componentType: 'TIMELINE_ATOM',
+                            id,
+                            products: [],
+                            labels: [],
+                        },
+                        action: 'LIKE',
+                    })
+                }
             />
         </Container>
     );

--- a/src/lib/ophan.ts
+++ b/src/lib/ophan.ts
@@ -1,0 +1,46 @@
+import type { OphanComponentEvent } from '@guardian/libs';
+
+declare global {
+    /* ~ Here, declare things that go in the global namespace, or augment
+     *~ existing declarations in the global namespace
+     */
+    interface Window {
+        guardian: {
+            ophan: {
+                setEventEmitter: () => void; // We don't currently have a custom eventEmitter on DCR - like 'mediator' in Frontend.
+                trackComponentAttention: (
+                    name: string,
+                    el: Element,
+                    visiblityThreshold: number,
+                ) => void;
+                record: () => void;
+                viewId: string;
+                pageViewId: string;
+            };
+        };
+    }
+}
+
+type OphanRecordFunction = (event: { [key: string]: any }) => void;
+
+const getOphanRecordFunction = (): OphanRecordFunction => {
+    const record =
+        window &&
+        window.guardian &&
+        window.guardian.ophan &&
+        window.guardian.ophan.record;
+
+    if (record) {
+        return record;
+    }
+    console.log('window.guardian.ophan.record is not available');
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    return () => {};
+};
+
+export const submitComponentEvent = (
+    componentEvent: OphanComponentEvent,
+): void => {
+    const record = getOphanRecordFunction();
+    record({ componentEvent });
+};

--- a/src/lib/ophan.ts
+++ b/src/lib/ophan.ts
@@ -1,5 +1,14 @@
 import type { OphanComponentEvent } from '@guardian/libs';
 
+/**
+ * This code is duplicated from DCR. This is intentional. We do not have an established
+ * centralised solution for this type of code (making tracking requests) but it is
+ * an area we are thinking about. In the meantime, we are keeping use cases separate
+ * so that it will be easier to make any transition to a centralised solution
+ * later
+ *
+ * See: https://github.com/guardian/dotcom-rendering/blob/88a31f1d74d2fb09d051ff75b513b4cbf31fdd23/dotcom-rendering/src/web/browser/ophan/ophan.ts
+ */
 declare global {
     /* ~ Here, declare things that go in the global namespace, or augment
      *~ existing declarations in the global namespace

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,9 +41,9 @@ export type GuideAtomType = {
     credit?: string;
     pillar: ArticleTheme;
     expandForStorybook?: boolean;
-    likeHandler: () => void;
-    dislikeHandler: () => void;
-    expandCallback: () => void;
+    likeHandler?: () => void;
+    dislikeHandler?: () => void;
+    expandCallback?: () => void;
 };
 
 export type InteractiveAtomBlockElementType = {
@@ -73,9 +73,9 @@ export type ProfileAtomType = {
     credit?: string;
     pillar: ArticleTheme;
     expandForStorybook?: boolean;
-    likeHandler: () => void;
-    dislikeHandler: () => void;
-    expandCallback: () => void;
+    likeHandler?: () => void;
+    dislikeHandler?: () => void;
+    expandCallback?: () => void;
 };
 
 export type QandaAtomType = {
@@ -86,9 +86,9 @@ export type QandaAtomType = {
     credit?: string;
     pillar: ArticleTheme;
     expandForStorybook?: boolean;
-    likeHandler: () => void;
-    dislikeHandler: () => void;
-    expandCallback: () => void;
+    likeHandler?: () => void;
+    dislikeHandler?: () => void;
+    expandCallback?: () => void;
 };
 
 export type TimelineAtomType = {
@@ -98,9 +98,9 @@ export type TimelineAtomType = {
     pillar: ArticleTheme;
     description?: string;
     expandForStorybook?: boolean;
-    likeHandler: () => void;
-    dislikeHandler: () => void;
-    expandCallback: () => void;
+    likeHandler?: () => void;
+    dislikeHandler?: () => void;
+    expandCallback?: () => void;
 };
 
 export interface TimelineEvent {


### PR DESCRIPTION
## What does this change?
This makes the tracking handlers used by some atoms optional

## Why?
We allow these handlers to be passed in in case different platforms want to track things differently. This change still allows this but adds a default so the handler is no longer required