### PR TITLE
Fix `YoutubeAtom` Ophan and GA Events

### DIFF
--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -220,6 +220,9 @@ export const YoutubeAtom = ({
 
         // We don't want to ever load the iframe until we know the reader's consent preferences
         if (!consentState) return;
+        // We don't want to reset the iframeSrc if it has already been set
+        // Resetting the iframe will wipe the player state and all listeners
+        if (iframeSrc) return;
 
         const adsConfig: AdsConfig =
             !adTargeting || adTargeting.disableAds


### PR DESCRIPTION
## What does this change?

Currently `YoutubeAtom` does not fire it's `EventEmitters` i.e. Ophan and GA. 

The root cause of this is that we are loading the YouTube iFrame twice.

This is because the `setIframeSrc` useEffect fires twice:
-  the first time when `loadIframe` becomes true (when `interactionStarted`)
-  the second time is when `hasUserLaunchedPlay` toggles  (when the user clicks play).

The second iFrame load causes the first player instance to be removed, taking the attached player and all the listeners with it.

The temporary fix is to not call `setIframeSrc` a second time.

It is a temporary fix as we plan to refactor this component to simplify the internal state, logic and separate the player from the UI.

## How can we measure success?

We don't load the iFrame twice.

Ophan and GA progress events should fire: `play`, `25`, `50`, `75`, `end`

## Images

### Before:

IFrames:

<img width="397" alt="Screenshot 2022-02-11 at 00 52 27-ci-build" src="https://user-images.githubusercontent.com/7014230/153625400-228e1a37-635a-4fab-9f06-8a5769ef0007.png">

No Ophan events

### After:

IFrame:

<img width="371" alt="Screenshot 2022-02-11 at 01 13 28-ci-fix" src="https://user-images.githubusercontent.com/7014230/153625568-fc9f8b04-3759-42c9-ae8d-54ebcc0b8c19.png">

Ophan events:

<img width="1105" alt="Screenshot 2022-02-11 at 01 20 52-dev-fix" src="https://user-images.githubusercontent.com/7014230/153625781-4590df42-2d69-4a27-a6d8-40683b3c820f.png">




