### PR TITLE
Remove interaction optimisation on `YouTubeAtom`

### DIFF
--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -162,9 +162,7 @@ export const YoutubeAtom = ({
     pillar,
 }: Props): JSX.Element => {
     const [iframeSrc, setIframeSrc] = useState<string | undefined>(undefined);
-    const [hasUserLaunchedPlay, setHasUserLaunchedPlay] = useState<boolean>(
-        false,
-    );
+    const [overlayClicked, setOverlayClicked] = useState<boolean>(false);
     const player = useRef<YoutubePlayerType>();
 
     const hasOverlay = overrideImage || posterImage;
@@ -177,7 +175,7 @@ export const YoutubeAtom = ({
      *
      * - It hasn't been clicked upon
      */
-    const showOverlay = hasOverlay && !hasUserLaunchedPlay;
+    const showOverlay = hasOverlay && !overlayClicked;
     /**
      * Show a placeholder if:
      *
@@ -189,7 +187,7 @@ export const YoutubeAtom = ({
      * still waiting on consent
      *
      */
-    const showPlaceholder = !iframeSrc && (!hasOverlay || hasUserLaunchedPlay);
+    const showPlaceholder = !iframeSrc && (!hasOverlay || overlayClicked);
 
     let loadIframe: boolean;
     if (!iframeSrc) {
@@ -198,7 +196,7 @@ export const YoutubeAtom = ({
     } else if (!hasOverlay) {
         // Always load the iframe if there is no overlay
         loadIframe = true;
-    } else if (hasUserLaunchedPlay) {
+    } else if (overlayClicked) {
         // The overlay has been clicked so we should load the iframe
         loadIframe = true;
     } else {
@@ -236,7 +234,7 @@ export const YoutubeAtom = ({
         setIframeSrc(
             `https://www.youtube.com/embed/${assetId}?embed_config=${embedConfig}&enablejsapi=1&widgetid=1&modestbranding=1${originString}&autoplay=1`,
         );
-    }, [consentState, hasUserLaunchedPlay]);
+    }, [consentState, overlayClicked]);
 
     useEffect(() => {
         if (loadIframe) {
@@ -374,14 +372,14 @@ export const YoutubeAtom = ({
                     data-cy="youtube-overlay"
                     data-testid="youtube-overlay"
                     onClick={() => {
-                        setHasUserLaunchedPlay(true);
+                        setOverlayClicked(true);
                         iframeSrc &&
                             player.current &&
                             player.current.playVideo();
                     }}
                     onKeyDown={(e) => {
                         if (e.code === 'Space' || e.code === 'Enter') {
-                            setHasUserLaunchedPlay(true);
+                            setOverlayClicked(true);
                             iframeSrc &&
                                 player.current &&
                                 player.current.playVideo();
@@ -389,7 +387,7 @@ export const YoutubeAtom = ({
                     }}
                     css={[
                         overlayStyles,
-                        hasUserLaunchedPlay ? hideOverlayStyling : '',
+                        overlayClicked ? hideOverlayStyling : '',
                         css`
                             img {
                                 height: 100%;

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -165,9 +165,6 @@ export const YoutubeAtom = ({
     const [hasUserLaunchedPlay, setHasUserLaunchedPlay] = useState<boolean>(
         false,
     );
-    const [interactionStarted, setInteractionStarted] = useState<boolean>(
-        false,
-    );
     const player = useRef<YoutubePlayerType>();
 
     const hasOverlay = overrideImage || posterImage;
@@ -205,8 +202,7 @@ export const YoutubeAtom = ({
         // The overlay has been clicked so we should load the iframe
         loadIframe = true;
     } else {
-        // Load early when either the mouse over or touch start event is fired
-        loadIframe = interactionStarted;
+        loadIframe = false;
     }
 
     useEffect(() => {
@@ -237,15 +233,8 @@ export const YoutubeAtom = ({
         const originString = origin
             ? `&origin=${encodeURIComponent(origin)}`
             : '';
-        // `autoplay`?
-        // We don't typically autoplay videos but in this case, where we know the reader has
-        // already clicked to play, we use this param to ensure the video plays. Why would it
-        // not play? Because when a reader clicks, we call player.current.playVideo() but at
-        // that point the video may not have loaded and the click event won't work. Autoplay
-        // is a failsafe for this scenario.
-        const autoplay = hasUserLaunchedPlay ? '&autoplay=1' : '';
         setIframeSrc(
-            `https://www.youtube.com/embed/${assetId}?embed_config=${embedConfig}&enablejsapi=1&widgetid=1&modestbranding=1${originString}${autoplay}`,
+            `https://www.youtube.com/embed/${assetId}?embed_config=${embedConfig}&enablejsapi=1&widgetid=1&modestbranding=1${originString}&autoplay=1`,
         );
     }, [consentState, hasUserLaunchedPlay]);
 
@@ -398,8 +387,6 @@ export const YoutubeAtom = ({
                                 player.current.playVideo();
                         }
                     }}
-                    onMouseEnter={() => setInteractionStarted(true)}
-                    onTouchStart={() => setInteractionStarted(true)}
                     css={[
                         overlayStyles,
                         hasUserLaunchedPlay ? hideOverlayStyling : '',


### PR DESCRIPTION
## What does this change?
This PR removes an optimisation that existed on the `YouTubeAtom` to download the youtube files early when the mouseover event fired.

## Why?
The existence of this optimisation is a problem for two reasons:

1. It is complicating state management and causing bugs. In some situations we're seeing videos not being played (especially in conjunction with a [recent PR ](https://github.com/guardian/atoms-rendering/pull/330)to prevent the iframe being loaded twice).
2. We intend to refactor this component and simpler state will be easier to reason about

This means that, in those cases where the optimisation was triggered (desktop, mainly) we're now asking the user to wait longer for the content to play. In most situations the time between `mouseover` and `click` is so small this will make little difference but where it does the flow already has a spinner incorporated as part of YT's ui so any delay is mitigated.