### PR TITLE
refactor: use URLSearchParams to create search params

### DIFF
--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -227,13 +227,20 @@ export const YoutubeAtom = ({
                       adTargeting.customParams,
                       consentState,
                   );
-        const embedConfig = encodeURIComponent(JSON.stringify({ adsConfig }));
-        const originString = origin
-            ? `&origin=${encodeURIComponent(origin)}`
-            : '';
-        setIframeSrc(
-            `https://www.youtube.com/embed/${assetId}?embed_config=${embedConfig}&enablejsapi=1&widgetid=1&modestbranding=1${originString}&autoplay=1`,
+
+        const params = new URLSearchParams({
+            ...(origin ? { origin: encodeURIComponent(origin) } : undefined),
+            autoplay: '1',
+            embed_config: encodeURIComponent(JSON.stringify({ adsConfig })),
+            enablejsapi: '1',
+            modestbranding: '1',
+            widgetid: '1',
+        });
+        const src = new URL(
+            `/embed/${assetId}?${params.toString()}`,
+            'https://www.youtube.com',
         );
+        setIframeSrc(src.toString());
     }, [consentState, overlayClicked]);
 
     useEffect(() => {

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -229,16 +229,16 @@ export const YoutubeAtom = ({
                   );
 
         const params = new URLSearchParams({
-            ...(origin ? { origin: encodeURIComponent(origin) } : undefined),
+            ...(origin ? { origin } : undefined),
             autoplay: '1',
-            embed_config: encodeURIComponent(JSON.stringify({ adsConfig })),
+            embed_config: JSON.stringify({ adsConfig }),
             enablejsapi: '1',
             modestbranding: '1',
             widgetid: '1',
         });
         const src = new URL(
             `/embed/${assetId}?${params.toString()}`,
-            'https://www.youtube.com',
+            'https://www.youtube.com/',
         );
         setIframeSrc(src.toString());
     }, [consentState, overlayClicked]);

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -229,7 +229,7 @@ export const YoutubeAtom = ({
                   );
 
         const params = new URLSearchParams({
-            ...(origin ? { origin } : undefined),
+            ...(origin ? { origin } : {}),
             autoplay: '1',
             embed_config: JSON.stringify({ adsConfig }),
             enablejsapi: '1',


### PR DESCRIPTION
## What does this change?

Use the platform! We can get rid of `encodeURIComponent`.

## How can we measure success?

Easier for people to feel confident making changes.

## Have we considered potential risks?

If the string was formatted differently, we might have issues with Youtube atoms. Hopefully these would be caught by existing tests.