### PR TITLE
Add event emitters for `resume`, `pause` and `cued`

### DIFF
--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -100,6 +100,21 @@ const createOnStateChangeListener = (
             setTimeout(() => {
                 checkProgress();
             }, 3000);
+        } else {
+            log('dotcom', {
+                from: loggerFrom,
+                videoId,
+                msg: 'resume play',
+                event,
+            });
+            eventEmitters.forEach((eventEmitter) => eventEmitter('resume'));
+
+            /**
+             * Set a timeout to check progress again in the future
+             */
+            setTimeout(() => {
+                checkProgress();
+            }, 3000);
         }
 
         const checkProgress = async () => {
@@ -153,6 +168,26 @@ const createOnStateChangeListener = (
                 setTimeout(() => checkProgress(), 3000);
             }
         };
+    }
+
+    if (event.data === YT.PlayerState.PAUSED) {
+        log('dotcom', {
+            from: loggerFrom,
+            videoId,
+            msg: 'paused',
+            event,
+        });
+        eventEmitters.forEach((eventEmitter) => eventEmitter('pause'));
+    }
+
+    if (event.data === YT.PlayerState.CUED) {
+        log('dotcom', {
+            from: loggerFrom,
+            videoId,
+            msg: 'cued',
+            event,
+        });
+        eventEmitters.forEach((eventEmitter) => eventEmitter('cued'));
     }
 
     if (

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -108,13 +108,6 @@ const createOnStateChangeListener = (
                 event,
             });
             eventEmitters.forEach((eventEmitter) => eventEmitter('resume'));
-
-            /**
-             * Set a timeout to check progress again in the future
-             */
-            setTimeout(() => {
-                checkProgress();
-            }, 3000);
         }
 
         const checkProgress = async () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -157,6 +157,15 @@ export type SharingUrlsType = {
     };
 };
 
-export type VideoEventKey = 'play' | '25' | '50' | '75' | 'end' | 'skip';
+export type VideoEventKey =
+    | 'play'
+    | '25'
+    | '50'
+    | '75'
+    | 'end'
+    | 'skip'
+    | 'pause'
+    | 'resume'
+    | 'cued';
 
 export type VideoControls = 'play' | 'stop' | 'pause';


### PR DESCRIPTION
## What does this change?

As part of the sticky video work we need to have greater awareness of the player state of youtube videos.

This PR adds the following event emitters:
- `resume` if the player has already played once but been paused
- `paused` if the player has been paused
- `cued` if the player has been stopped

Given we don't need to send these events to Ophan or GA i'm unsure as to whether we need to include the `log()` sections?


## How to test

Go to storybook, open dev tools and play / pause / stop the video.


