### PR TITLE
Add `setIsPlaying` callback to `YoutubeAtom`

### DIFF
--- a/src/YoutubeAtom.stories.tsx
+++ b/src/YoutubeAtom.stories.tsx
@@ -28,7 +28,7 @@ export const NoConsent = (): JSX.Element => {
                 pillar={ArticlePillar.Culture}
                 height={450}
                 width={800}
-                setIsPlaying={(e) => console.log(`video is playing: ${e}`)}
+                setIsPlaying={(x) => console.log(`video is playing: ${x}`)}
             />
         </div>
     );
@@ -54,7 +54,7 @@ export const NoOverlay = (): JSX.Element => {
                 pillar={ArticlePillar.Culture}
                 height={450}
                 width={800}
-                setIsPlaying={(e) => console.log(`video is playing: ${e}`)}
+                setIsPlaying={(x) => console.log(`video is playing: ${x}`)}
             />
         </div>
     );
@@ -89,7 +89,7 @@ export const WithOverrideImage = (): JSX.Element => {
                         ],
                     },
                 ]}
-                setIsPlaying={(e) => console.log(`video is playing: ${e}`)}
+                setIsPlaying={(x) => console.log(`video is playing: ${x}`)}
             />
         </div>
     );
@@ -141,7 +141,7 @@ export const WithPosterImage = (): JSX.Element => {
                 ]}
                 height={450}
                 width={800}
-                setIsPlaying={(e) => console.log(`video is playing: ${e}`)}
+                setIsPlaying={(x) => console.log(`video is playing: ${x}`)}
             />
         </div>
     );
@@ -204,7 +204,7 @@ export const WithOverlayAndPosterImage = (): JSX.Element => {
                 ]}
                 height={450}
                 width={800}
-                setIsPlaying={(e) => console.log(`video is playing: ${e}`)}
+                setIsPlaying={(x) => console.log(`video is playing: ${x}`)}
             />
         </div>
     );
@@ -244,7 +244,7 @@ export const GiveConsent = (): JSX.Element => {
                     ]}
                     height={450}
                     width={800}
-                    setIsPlaying={(e) => console.log(`video is playing: ${e}`)}
+                    setIsPlaying={(x) => console.log(`video is playing: ${x}`)}
                 />
             </div>
         </>

--- a/src/YoutubeAtom.stories.tsx
+++ b/src/YoutubeAtom.stories.tsx
@@ -28,7 +28,7 @@ export const NoConsent = (): JSX.Element => {
                 pillar={ArticlePillar.Culture}
                 height={450}
                 width={800}
-                setIsPlaying={() => console.log('set is playing')}
+                setIsPlaying={(e) => console.log(`video is playing: ${e}`)}
             />
         </div>
     );
@@ -54,7 +54,7 @@ export const NoOverlay = (): JSX.Element => {
                 pillar={ArticlePillar.Culture}
                 height={450}
                 width={800}
-                setIsPlaying={() => console.log('set is playing')}
+                setIsPlaying={(e) => console.log(`video is playing: ${e}`)}
             />
         </div>
     );
@@ -89,7 +89,7 @@ export const WithOverrideImage = (): JSX.Element => {
                         ],
                     },
                 ]}
-                setIsPlaying={() => console.log('set is playing')}
+                setIsPlaying={(e) => console.log(`video is playing: ${e}`)}
             />
         </div>
     );
@@ -141,7 +141,7 @@ export const WithPosterImage = (): JSX.Element => {
                 ]}
                 height={450}
                 width={800}
-                setIsPlaying={() => console.log('set is playing')}
+                setIsPlaying={(e) => console.log(`video is playing: ${e}`)}
             />
         </div>
     );
@@ -204,7 +204,7 @@ export const WithOverlayAndPosterImage = (): JSX.Element => {
                 ]}
                 height={450}
                 width={800}
-                setIsPlaying={() => console.log('set is playing')}
+                setIsPlaying={(e) => console.log(`video is playing: ${e}`)}
             />
         </div>
     );
@@ -244,7 +244,7 @@ export const GiveConsent = (): JSX.Element => {
                     ]}
                     height={450}
                     width={800}
-                    setIsPlaying={() => console.log('set is playing')}
+                    setIsPlaying={(e) => console.log(`video is playing: ${e}`)}
                 />
             </div>
         </>

--- a/src/YoutubeAtom.stories.tsx
+++ b/src/YoutubeAtom.stories.tsx
@@ -28,6 +28,7 @@ export const NoConsent = (): JSX.Element => {
                 pillar={ArticlePillar.Culture}
                 height={450}
                 width={800}
+                setIsPlaying={() => console.log('set is playing')}
             />
         </div>
     );
@@ -53,6 +54,7 @@ export const NoOverlay = (): JSX.Element => {
                 pillar={ArticlePillar.Culture}
                 height={450}
                 width={800}
+                setIsPlaying={() => console.log('set is playing')}
             />
         </div>
     );
@@ -87,6 +89,7 @@ export const WithOverrideImage = (): JSX.Element => {
                         ],
                     },
                 ]}
+                setIsPlaying={() => console.log('set is playing')}
             />
         </div>
     );
@@ -138,6 +141,7 @@ export const WithPosterImage = (): JSX.Element => {
                 ]}
                 height={450}
                 width={800}
+                setIsPlaying={() => console.log('set is playing')}
             />
         </div>
     );
@@ -200,6 +204,7 @@ export const WithOverlayAndPosterImage = (): JSX.Element => {
                 ]}
                 height={450}
                 width={800}
+                setIsPlaying={() => console.log('set is playing')}
             />
         </div>
     );
@@ -239,6 +244,7 @@ export const GiveConsent = (): JSX.Element => {
                     ]}
                     height={450}
                     width={800}
+                    setIsPlaying={() => console.log('set is playing')}
                 />
             </div>
         </>

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -27,6 +27,7 @@ type Props = {
     origin?: string;
     eventEmitters: ((event: VideoEventKey) => void)[];
     pillar: ArticleTheme;
+    setIsPlaying: (arg: boolean) => void;
 };
 
 export const YoutubeAtom = ({
@@ -44,6 +45,7 @@ export const YoutubeAtom = ({
     origin,
     eventEmitters,
     pillar,
+    setIsPlaying,
 }: Props): JSX.Element => {
     const [overlayClicked, setOverlayClicked] = useState<boolean>(false);
     const [playerReady, setPlayerReady] = useState<boolean>(false);
@@ -108,6 +110,7 @@ export const YoutubeAtom = ({
                      */
                     autoPlay={hasOverlay}
                     onReady={playerReadyCallback}
+                    setIsPlaying={setIsPlaying}
                 />
             )}
             {showOverlay && (

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -23,7 +23,7 @@ type Props = {
     eventEmitters: ((event: VideoEventKey) => void)[];
     autoPlay: boolean;
     onReady: () => void;
-    setIsPlaying: (arg: boolean) => void;
+    setIsPlaying: (x: boolean) => void;
 };
 
 declare global {
@@ -87,6 +87,10 @@ const createOnStateChangeListener = (
             });
             eventEmitters.forEach((eventEmitter) => eventEmitter('play'));
             progressEvents.hasSentPlayEvent = true;
+
+            /**
+             * Callback to notify that the player is playing
+             */
             setIsPlaying(true);
 
             /**

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -167,6 +167,7 @@ const createOnStateChangeListener = (
             event,
         });
         eventEmitters.forEach((eventEmitter) => eventEmitter('pause'));
+        setIsPlaying(false);
     }
 
     if (event.data === YT.PlayerState.CUED) {

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -23,6 +23,7 @@ type Props = {
     eventEmitters: ((event: VideoEventKey) => void)[];
     autoPlay: boolean;
     onReady: () => void;
+    setIsPlaying: (arg: boolean) => void;
 };
 
 declare global {
@@ -62,6 +63,7 @@ const createOnStateChangeListener = (
     videoId: string,
     progressEvents: ProgressEvents,
     eventEmitters: Props['eventEmitters'],
+    setIsPlaying: (arg: boolean) => void,
 ): YT.PlayerEventHandler<YT.OnStateChangeEvent> => (event) => {
     const loggerFrom = 'YoutubeAtomPlayer onStateChange';
     log('dotcom', {
@@ -85,6 +87,7 @@ const createOnStateChangeListener = (
             });
             eventEmitters.forEach((eventEmitter) => eventEmitter('play'));
             progressEvents.hasSentPlayEvent = true;
+            setIsPlaying(true);
 
             /**
              * Set a timeout to check progress again in the future
@@ -100,6 +103,7 @@ const createOnStateChangeListener = (
                 event,
             });
             eventEmitters.forEach((eventEmitter) => eventEmitter('resume'));
+            setIsPlaying(true);
         }
 
         const checkProgress = async () => {
@@ -173,6 +177,7 @@ const createOnStateChangeListener = (
             event,
         });
         eventEmitters.forEach((eventEmitter) => eventEmitter('cued'));
+        setIsPlaying(false);
     }
 
     if (
@@ -187,6 +192,7 @@ const createOnStateChangeListener = (
         });
         eventEmitters.forEach((eventEmitter) => eventEmitter('end'));
         progressEvents.hasSentEndEvent = true;
+        setIsPlaying(false);
     }
 };
 
@@ -203,6 +209,7 @@ export const YoutubeAtomPlayer = ({
     eventEmitters,
     autoPlay,
     onReady,
+    setIsPlaying,
 }: Props): JSX.Element => {
     /**
      * useRef for player and progressEvents
@@ -264,6 +271,7 @@ export const YoutubeAtomPlayer = ({
                     videoId,
                     progressEvents.current,
                     eventEmitters,
+                    setIsPlaying,
                 );
 
                 player.current &&
@@ -327,6 +335,7 @@ export const YoutubeAtomPlayer = ({
             origin,
             videoId,
             width,
+            setIsPlaying,
         ],
     );
 


### PR DESCRIPTION
## What does this change?

This PR adds a `setIsPlaying` prop to the `YoutubeAtomPlayer` so we can provide a callback to set an `isPlaying` state any the parent component using the `YoutubeAtom`.

Previously we had been using the `eventEmitters` so send play events to the parent component via a callback, this new prop separates the concerns of tracking and play state.

In DCR we are then able to call this like so:
```javascript
	const isPlayingCallback = useCallback(
		(x: boolean) => setIsPlaying(x),
		[],
	);
	
	[...]
	return (
	    	<YoutubeAtom
	    	    setIsPlaying={isPlayingCallback}
	    	    [...]
	    	 />
	  );
```



## How to test

Run storybook and check the console for play events.

