### PR TITLE
Refine changesets workflow

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -28,11 +28,9 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          publish: yarn release:changesets
+          publish: yarn release
           title: "Bump packages"
           commit: "Bump packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-

--- a/README.md
+++ b/README.md
@@ -95,23 +95,11 @@ An example PR for adding the Profile Atom can be found [here](https://github.com
 
 ## Releasing a new version / Publishing to NPM
 
-Prerequisites:
+`atoms-rendering` is now published to NPM using [changesets](https://github.com/changesets/changesets)
 
-1. Ensure your changes are on main
-2. Ensure you have an [npm account](https://docs.npmjs.com/creating-and-publishing-scoped-public-packages) that is authorised for the npm @guardian organisation
-3. If it is your first time to do a release, you might need to make NPM credentials available to your local instance. For this, go to your NPM account and generate a new access token with `publish` rights. Then issue
+Generate a changeset describing your work by running `yarn changeset` and following the prompts.
 
-```
-$ echo "//registry.npmjs.org/:_authToken=YOUR-ACCESS-TOKEN" > ~/.npmrc
-```
-
-replacing YOUR-ACCESS-TOKEN with your own access token
-
-Then:
-
-`yarn release --patch` or `yarn release --minor` or `yarn release --major`
-
-You might still have to interactively specify the level or release (`patch`, `minor` or `major`) and a prompt will invite you to make a tag release on Github.
+Publishing is triggered by merging the auto-generated Version Packages PR that changesets manages.
 
 Once complete, you can update the version of `@guardian/atoms-rendering` in any consuming project to see the changes
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Generate a changeset describing your work by running `yarn changeset` and follow
 
 Publishing is triggered by merging the auto-generated Version Packages PR that changesets manages.
 
-Once complete, you can update the version of `@guardian/atoms-rendering` in any consuming project to see the changes
+Once complete, you can update the version of `@guardian/atoms-rendering` in any consuming project to see the changes.
 
 ## Snyk Code Scanning
 

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
         "test:ci": "jest",
         "validate": "yarn tsc && yarn test:ci && yarn lint",
         "chromatic": "chromatic",
-        "release": "yarn validate && yarn build && np --no-tests",
-        "release:changesets": "yarn validate && yarn build && changeset publish"
+        "release": "yarn validate && yarn build && changeset publish"
     },
     "devDependencies": {
         "@changesets/changelog-github": "^0.4.3",


### PR DESCRIPTION
## What does this change?

Makes changesets the default release method.

Removes unused `NODE_AUTH_TOKEN` value.

