### PR TITLE
Reinstate NODE_AUTH_TOKEN

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -29,8 +29,10 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: yarn release
-          title: "Bump packages"
-          commit: "Bump packages"
+          title: "Bump version"
+          commit: "Bump version"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+


### PR DESCRIPTION
## What does this change?

Reinstate `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` as removing it seems to have broken the release process :/