### PR TITLE
Reorder `YoutubeAtomSticky` contents

### DIFF
--- a/.changeset/tall-dodos-check.md
+++ b/.changeset/tall-dodos-check.md
@@ -1,0 +1,5 @@
+---
+'@guardian/atoms-rendering': patch
+---
+
+Fix rerender bug when sticking and unsticking

--- a/src/YoutubeAtom.stories.tsx
+++ b/src/YoutubeAtom.stories.tsx
@@ -255,22 +255,20 @@ export const Sticky = (): JSX.Element => {
     return (
         <div>
             <div style={{ height: '1000px' }}></div>
-            <div>
-                <YoutubeAtom
-                    assetId="-ZCvZmYlQD8"
-                    alt=""
-                    role="inline"
-                    eventEmitters={[
-                        (e) => console.log(`analytics event ${e} called`),
-                    ]}
-                    consentState={{}}
-                    duration={252}
-                    pillar={ArticlePillar.Culture}
-                    height={450}
-                    width={800}
-                    shouldStick={true}
-                />
-            </div>
+            <YoutubeAtom
+                assetId="-ZCvZmYlQD8"
+                alt=""
+                role="inline"
+                eventEmitters={[
+                    (e) => console.log(`analytics event ${e} called`),
+                ]}
+                consentState={{}}
+                duration={252}
+                pillar={ArticlePillar.Culture}
+                height={450}
+                width={800}
+                shouldStick={true}
+            />
             <div style={{ height: '1000px' }}></div>
         </div>
     );

--- a/src/YoutubeAtomSticky.tsx
+++ b/src/YoutubeAtomSticky.tsx
@@ -161,6 +161,7 @@ export const YoutubeAtomSticky = ({
     return (
         <div ref={setRef} css={isSticky && stickyContainerStyles(192)}>
             <div css={isSticky && stickyStyles}>
+                {children}
                 {isSticky && (
                     <>
                         <span css={hoverAreaStyles} />
@@ -169,7 +170,6 @@ export const YoutubeAtomSticky = ({
                         </button>
                     </>
                 )}
-                {children}
             </div>
         </div>
     );


### PR DESCRIPTION
## What does this change?

Re-orders the contents of the `YoutubeAtomSticky` component so `children` come before the close button. This means that when the button html is conditionally rendered or not, the order of the child components does not change.