### PR TITLE
Close sticky video on esc press

### DIFF
--- a/.changeset/small-jobs-shave.md
+++ b/.changeset/small-jobs-shave.md
@@ -1,0 +1,5 @@
+---
+'@guardian/atoms-rendering': patch
+---
+
+Close sticky video on ESC key press

--- a/src/YoutubeAtomSticky.tsx
+++ b/src/YoutubeAtomSticky.tsx
@@ -136,6 +136,27 @@ export const YoutubeAtomSticky = ({
     };
 
     /**
+     * keydown event handler
+     *
+     * closes sticky video when Escape key is pressed
+     */
+    const handleKeydown = (e: { key: string }) => {
+        if (e.key === 'Escape') {
+            handleCloseClick();
+        }
+    };
+
+    /**
+     * useEffect to create keydown listener
+     */
+    useEffect(() => {
+        console.log('here');
+        document.addEventListener('keydown', handleKeydown);
+
+        return () => document.removeEventListener('keydown', handleKeydown);
+    }, []);
+
+    /**
      * useEffect for the sticky state
      */
     useEffect(() => {


### PR DESCRIPTION
## What does this change?

Adds a listener to allow users to closes the sticky video on `esc` key press.

## How to test

Run storybook, go to the `YoutubeAtom/sticky` story, play the video, scroll down to stick and close using the `escape` key. 
