### PR TITLE
YoutubeAtom - Fix Duplicate Videos

### DIFF
--- a/.changeset/gorgeous-fans-peel.md
+++ b/.changeset/gorgeous-fans-peel.md
@@ -1,0 +1,5 @@
+---
+'@guardian/atoms-rendering': major
+---
+
+YoutubeAtom duplicate video fix

--- a/src/YoutubeAtom.stories.tsx
+++ b/src/YoutubeAtom.stories.tsx
@@ -271,6 +271,7 @@ export const StickyMainMedia = (): JSX.Element => {
         <div>
             <div style={{ height: '1000px' }}></div>
             <YoutubeAtom
+                elementId="xyz"
                 videoId="-ZCvZmYlQD8"
                 alt=""
                 role="inline"

--- a/src/YoutubeAtom.stories.tsx
+++ b/src/YoutubeAtom.stories.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { css } from '@emotion/react';
 
 import { YoutubeAtom } from './YoutubeAtom';
 import { ArticlePillar } from '@guardian/libs';
@@ -9,14 +8,12 @@ export default {
     component: YoutubeAtom,
 };
 
+const containerStyle = { width: '800px', margin: '24px' };
+const containerStyleSmall = { width: '400px', margin: '24px' };
+
 export const NoConsent = (): JSX.Element => {
     return (
-        <div
-            css={css`
-                width: 800px;
-                margin: 25px;
-            `}
-        >
+        <div style={containerStyle}>
             <YoutubeAtom
                 elementId="xyz"
                 videoId="-ZCvZmYlQD8"
@@ -38,12 +35,7 @@ export const NoConsent = (): JSX.Element => {
 
 export const NoOverlay = (): JSX.Element => {
     return (
-        <div
-            css={css`
-                width: 800px;
-                margin: 25px;
-            `}
-        >
+        <div style={containerStyle}>
             <YoutubeAtom
                 elementId="xyz"
                 videoId="-ZCvZmYlQD8"
@@ -67,12 +59,7 @@ export const NoOverlay = (): JSX.Element => {
 
 export const WithOverrideImage = (): JSX.Element => {
     return (
-        <div
-            css={css`
-                width: 800px;
-                margin: 25px;
-            `}
-        >
+        <div style={containerStyle}>
             <YoutubeAtom
                 elementId="xyz"
                 videoId="3jpXAMwRSu4"
@@ -105,12 +92,7 @@ export const WithOverrideImage = (): JSX.Element => {
 
 export const WithPosterImage = (): JSX.Element => {
     return (
-        <div
-            css={css`
-                width: 800px;
-                margin: 25px;
-            `}
-        >
+        <div style={containerStyle}>
             <YoutubeAtom
                 elementId="xyz"
                 videoId="N9Cgy-ke5-s"
@@ -160,12 +142,7 @@ export const WithPosterImage = (): JSX.Element => {
 
 export const WithOverlayAndPosterImage = (): JSX.Element => {
     return (
-        <div
-            css={css`
-                width: 800px;
-                margin: 25px;
-            `}
-        >
+        <div style={containerStyle}>
             <YoutubeAtom
                 elementId="xyz"
                 videoId="N9Cgy-ke5-s"
@@ -229,12 +206,7 @@ export const GiveConsent = (): JSX.Element => {
     return (
         <>
             <button onClick={() => setConsented(true)}>Give consent</button>
-            <div
-                css={css`
-                    width: 800px;
-                    margin: 25px;
-                `}
-            >
+            <div style={containerStyle}>
                 <YoutubeAtom
                     elementId="xyz"
                     videoId="3jpXAMwRSu4"
@@ -321,12 +293,7 @@ export const StickyMainMedia = (): JSX.Element => {
 
 export const DuplicateVideos = (): JSX.Element => {
     return (
-        <div
-            css={css`
-                width: 400px;
-                margin: 25px;
-            `}
-        >
+        <div style={containerStyleSmall}>
             <YoutubeAtom
                 elementId="xyz"
                 videoId="-ZCvZmYlQD8"

--- a/src/YoutubeAtom.stories.tsx
+++ b/src/YoutubeAtom.stories.tsx
@@ -18,6 +18,7 @@ export const NoConsent = (): JSX.Element => {
             `}
         >
             <YoutubeAtom
+                id="xyz"
                 assetId="-ZCvZmYlQD8"
                 alt=""
                 role="inline"
@@ -44,6 +45,7 @@ export const NoOverlay = (): JSX.Element => {
             `}
         >
             <YoutubeAtom
+                id="xyz"
                 assetId="-ZCvZmYlQD8"
                 alt=""
                 role="inline"
@@ -72,6 +74,7 @@ export const WithOverrideImage = (): JSX.Element => {
             `}
         >
             <YoutubeAtom
+                id="xyz"
                 assetId="3jpXAMwRSu4"
                 alt="Microscopic image of COVID"
                 role="inline"
@@ -109,6 +112,7 @@ export const WithPosterImage = (): JSX.Element => {
             `}
         >
             <YoutubeAtom
+                id="xyz"
                 assetId="N9Cgy-ke5-s"
                 alt=""
                 role="inline"
@@ -163,6 +167,7 @@ export const WithOverlayAndPosterImage = (): JSX.Element => {
             `}
         >
             <YoutubeAtom
+                id="xyz"
                 assetId="N9Cgy-ke5-s"
                 alt=""
                 role="inline"
@@ -231,6 +236,7 @@ export const GiveConsent = (): JSX.Element => {
                 `}
             >
                 <YoutubeAtom
+                    id="xyz"
                     assetId="3jpXAMwRSu4"
                     alt="Microscopic image of COVID"
                     role="inline"
@@ -267,6 +273,7 @@ export const Sticky = (): JSX.Element => {
         <div>
             <div style={{ height: '1000px' }}></div>
             <YoutubeAtom
+                id="xyz"
                 assetId="-ZCvZmYlQD8"
                 alt=""
                 role="inline"
@@ -308,6 +315,49 @@ export const StickyMainMedia = (): JSX.Element => {
                 title="Rayshard Brooks: US justice system treats us like 'animals'"
             />
             <div style={{ height: '1000px' }}></div>
+        </div>
+    );
+};
+
+export const DuplicateVideos = (): JSX.Element => {
+    return (
+        <div
+            css={css`
+                width: 400px;
+                margin: 25px;
+            `}
+        >
+            <YoutubeAtom
+                id="xyz"
+                assetId="-ZCvZmYlQD8"
+                alt=""
+                role="inline"
+                eventEmitters={[
+                    (e) => console.log(`analytics event ${e} called`),
+                ]}
+                consentState={{}}
+                duration={252}
+                pillar={ArticlePillar.Culture}
+                height={450}
+                width={800}
+                shouldStick={true}
+            />
+            <br />
+            <YoutubeAtom
+                id="xyz2"
+                assetId="-ZCvZmYlQD8"
+                alt=""
+                role="inline"
+                eventEmitters={[
+                    (e) => console.log(`analytics event ${e} called`),
+                ]}
+                consentState={{}}
+                duration={252}
+                pillar={ArticlePillar.Culture}
+                height={450}
+                width={800}
+                shouldStick={true}
+            />
         </div>
     );
 };

--- a/src/YoutubeAtom.stories.tsx
+++ b/src/YoutubeAtom.stories.tsx
@@ -18,7 +18,7 @@ export const NoConsent = (): JSX.Element => {
             `}
         >
             <YoutubeAtom
-                id="xyz"
+                elementId="xyz"
                 videoId="-ZCvZmYlQD8"
                 alt=""
                 role="inline"
@@ -45,7 +45,7 @@ export const NoOverlay = (): JSX.Element => {
             `}
         >
             <YoutubeAtom
-                id="xyz"
+                elementId="xyz"
                 videoId="-ZCvZmYlQD8"
                 alt=""
                 role="inline"
@@ -74,7 +74,7 @@ export const WithOverrideImage = (): JSX.Element => {
             `}
         >
             <YoutubeAtom
-                id="xyz"
+                elementId="xyz"
                 videoId="3jpXAMwRSu4"
                 alt="Microscopic image of COVID"
                 role="inline"
@@ -112,7 +112,7 @@ export const WithPosterImage = (): JSX.Element => {
             `}
         >
             <YoutubeAtom
-                id="xyz"
+                elementId="xyz"
                 videoId="N9Cgy-ke5-s"
                 alt=""
                 role="inline"
@@ -167,7 +167,7 @@ export const WithOverlayAndPosterImage = (): JSX.Element => {
             `}
         >
             <YoutubeAtom
-                id="xyz"
+                elementId="xyz"
                 videoId="N9Cgy-ke5-s"
                 alt=""
                 role="inline"
@@ -236,7 +236,7 @@ export const GiveConsent = (): JSX.Element => {
                 `}
             >
                 <YoutubeAtom
-                    id="xyz"
+                    elementId="xyz"
                     videoId="3jpXAMwRSu4"
                     alt="Microscopic image of COVID"
                     role="inline"
@@ -273,7 +273,7 @@ export const Sticky = (): JSX.Element => {
         <div>
             <div style={{ height: '1000px' }}></div>
             <YoutubeAtom
-                id="xyz"
+                elementId="xyz"
                 videoId="-ZCvZmYlQD8"
                 alt=""
                 role="inline"
@@ -328,7 +328,7 @@ export const DuplicateVideos = (): JSX.Element => {
             `}
         >
             <YoutubeAtom
-                id="xyz"
+                elementId="xyz"
                 videoId="-ZCvZmYlQD8"
                 alt=""
                 role="inline"
@@ -344,7 +344,7 @@ export const DuplicateVideos = (): JSX.Element => {
             />
             <br />
             <YoutubeAtom
-                id="xyz2"
+                elementId="xyz2"
                 videoId="-ZCvZmYlQD8"
                 alt=""
                 role="inline"

--- a/src/YoutubeAtom.stories.tsx
+++ b/src/YoutubeAtom.stories.tsx
@@ -19,7 +19,7 @@ export const NoConsent = (): JSX.Element => {
         >
             <YoutubeAtom
                 id="xyz"
-                assetId="-ZCvZmYlQD8"
+                videoId="-ZCvZmYlQD8"
                 alt=""
                 role="inline"
                 eventEmitters={[
@@ -46,7 +46,7 @@ export const NoOverlay = (): JSX.Element => {
         >
             <YoutubeAtom
                 id="xyz"
-                assetId="-ZCvZmYlQD8"
+                videoId="-ZCvZmYlQD8"
                 alt=""
                 role="inline"
                 eventEmitters={[
@@ -75,7 +75,7 @@ export const WithOverrideImage = (): JSX.Element => {
         >
             <YoutubeAtom
                 id="xyz"
-                assetId="3jpXAMwRSu4"
+                videoId="3jpXAMwRSu4"
                 alt="Microscopic image of COVID"
                 role="inline"
                 eventEmitters={[
@@ -113,7 +113,7 @@ export const WithPosterImage = (): JSX.Element => {
         >
             <YoutubeAtom
                 id="xyz"
-                assetId="N9Cgy-ke5-s"
+                videoId="N9Cgy-ke5-s"
                 alt=""
                 role="inline"
                 eventEmitters={[
@@ -168,7 +168,7 @@ export const WithOverlayAndPosterImage = (): JSX.Element => {
         >
             <YoutubeAtom
                 id="xyz"
-                assetId="N9Cgy-ke5-s"
+                videoId="N9Cgy-ke5-s"
                 alt=""
                 role="inline"
                 eventEmitters={[
@@ -237,7 +237,7 @@ export const GiveConsent = (): JSX.Element => {
             >
                 <YoutubeAtom
                     id="xyz"
-                    assetId="3jpXAMwRSu4"
+                    videoId="3jpXAMwRSu4"
                     alt="Microscopic image of COVID"
                     role="inline"
                     eventEmitters={[
@@ -274,7 +274,7 @@ export const Sticky = (): JSX.Element => {
             <div style={{ height: '1000px' }}></div>
             <YoutubeAtom
                 id="xyz"
-                assetId="-ZCvZmYlQD8"
+                videoId="-ZCvZmYlQD8"
                 alt=""
                 role="inline"
                 eventEmitters={[
@@ -299,7 +299,7 @@ export const StickyMainMedia = (): JSX.Element => {
         <div>
             <div style={{ height: '1000px' }}></div>
             <YoutubeAtom
-                assetId="-ZCvZmYlQD8"
+                videoId="-ZCvZmYlQD8"
                 alt=""
                 role="inline"
                 eventEmitters={[
@@ -329,7 +329,7 @@ export const DuplicateVideos = (): JSX.Element => {
         >
             <YoutubeAtom
                 id="xyz"
-                assetId="-ZCvZmYlQD8"
+                videoId="-ZCvZmYlQD8"
                 alt=""
                 role="inline"
                 eventEmitters={[
@@ -345,7 +345,7 @@ export const DuplicateVideos = (): JSX.Element => {
             <br />
             <YoutubeAtom
                 id="xyz2"
-                assetId="-ZCvZmYlQD8"
+                videoId="-ZCvZmYlQD8"
                 alt=""
                 role="inline"
                 eventEmitters={[

--- a/src/YoutubeAtom.test.tsx
+++ b/src/YoutubeAtom.test.tsx
@@ -22,7 +22,7 @@ describe('YoutubeAtom', () => {
             <YoutubeAtom
                 id="xyz"
                 title="My Youtube video!"
-                assetId="ZCvZmYlQD8"
+                videoId="ZCvZmYlQD8"
                 alt=""
                 role="inline"
                 eventEmitters={[]}
@@ -42,7 +42,7 @@ describe('YoutubeAtom', () => {
             <YoutubeAtom
                 id="xyz"
                 title="My Youtube video!"
-                assetId="ZCvZmYlQD8"
+                videoId="ZCvZmYlQD8"
                 alt=""
                 role="inline"
                 eventEmitters={[]}
@@ -71,7 +71,7 @@ describe('YoutubeAtom', () => {
             <YoutubeAtom
                 id="xyz"
                 title="My Youtube video!"
-                assetId="ZCvZmYlQD8"
+                videoId="ZCvZmYlQD8"
                 alt=""
                 role="inline"
                 eventEmitters={[]}
@@ -92,7 +92,7 @@ describe('YoutubeAtom', () => {
             <YoutubeAtom
                 id="xyz"
                 title="My Youtube video!"
-                assetId="ZCvZmYlQD8"
+                videoId="ZCvZmYlQD8"
                 alt=""
                 role="inline"
                 eventEmitters={[]}
@@ -115,7 +115,7 @@ describe('YoutubeAtom', () => {
             <YoutubeAtom
                 id="xyz"
                 title="My Youtube video!"
-                assetId="ZCvZmYlQD8"
+                videoId="ZCvZmYlQD8"
                 alt=""
                 role="inline"
                 eventEmitters={[]}
@@ -134,7 +134,7 @@ describe('YoutubeAtom', () => {
             <YoutubeAtom
                 id="xyz"
                 title="My Youtube video!"
-                assetId="ZCvZmYlQD8"
+                videoId="ZCvZmYlQD8"
                 alt=""
                 role="inline"
                 eventEmitters={[]}
@@ -154,7 +154,7 @@ describe('YoutubeAtom', () => {
             <YoutubeAtom
                 id="xyz"
                 title="My Youtube video!"
-                assetId="ZCvZmYlQD8"
+                videoId="ZCvZmYlQD8"
                 alt=""
                 role="inline"
                 eventEmitters={[]}
@@ -178,7 +178,7 @@ describe('YoutubeAtom', () => {
                 <YoutubeAtom
                     id="xyz"
                     title="My Youtube video!"
-                    assetId="ZCvZmYlQD8"
+                    videoId="ZCvZmYlQD8"
                     alt=""
                     role="inline"
                     eventEmitters={[]}
@@ -190,7 +190,7 @@ describe('YoutubeAtom', () => {
                 <YoutubeAtom
                     id="xyz"
                     title="My Youtube video 2!"
-                    assetId="ZCvZmYlQD8_2"
+                    videoId="ZCvZmYlQD8_2"
                     alt=""
                     role="inline"
                     eventEmitters={[]}

--- a/src/YoutubeAtom.test.tsx
+++ b/src/YoutubeAtom.test.tsx
@@ -20,6 +20,7 @@ describe('YoutubeAtom', () => {
     it('Player initialises when no overlay and has consent state', async () => {
         const atom = (
             <YoutubeAtom
+                id="xyz"
                 title="My Youtube video!"
                 assetId="ZCvZmYlQD8"
                 alt=""
@@ -32,13 +33,14 @@ describe('YoutubeAtom', () => {
             />
         );
         const { getByTestId } = render(atom);
-        const playerDiv = getByTestId('youtube-video-ZCvZmYlQD8');
+        const playerDiv = getByTestId('youtube-video-ZCvZmYlQD8-xyz');
         expect(playerDiv).toBeInTheDocument();
     });
 
     it('Player initialises when overlay clicked and has consent state', async () => {
         const atom = (
             <YoutubeAtom
+                id="xyz"
                 title="My Youtube video!"
                 assetId="ZCvZmYlQD8"
                 alt=""
@@ -52,13 +54,13 @@ describe('YoutubeAtom', () => {
             />
         );
         const { getByTestId } = render(atom);
-        const overlay = getByTestId('youtube-overlay-ZCvZmYlQD8');
+        const overlay = getByTestId('youtube-overlay-ZCvZmYlQD8-xyz');
         expect(overlay).toBeInTheDocument();
 
-        fireEvent.click(getByTestId('youtube-overlay-ZCvZmYlQD8'));
+        fireEvent.click(getByTestId('youtube-overlay-ZCvZmYlQD8-xyz'));
         expect(overlay).not.toBeInTheDocument();
 
-        const playerDiv = getByTestId('youtube-video-ZCvZmYlQD8');
+        const playerDiv = getByTestId('youtube-video-ZCvZmYlQD8-xyz');
         expect(playerDiv).toBeInTheDocument();
     });
 
@@ -109,6 +111,7 @@ describe('YoutubeAtom', () => {
     it('shows a placeholder if overlay is missing', async () => {
         const atom = (
             <YoutubeAtom
+                id="xyz"
                 title="My Youtube video!"
                 assetId="ZCvZmYlQD8"
                 alt=""
@@ -120,13 +123,14 @@ describe('YoutubeAtom', () => {
             />
         );
         const { getByTestId } = render(atom);
-        const placeholder = getByTestId('youtube-placeholder-ZCvZmYlQD8');
+        const placeholder = getByTestId('youtube-placeholder-ZCvZmYlQD8-xyz');
         expect(placeholder).toBeInTheDocument();
     });
 
     it('shows an overlay if present', async () => {
         const atom = (
             <YoutubeAtom
+                id="xyz"
                 title="My Youtube video!"
                 assetId="ZCvZmYlQD8"
                 alt=""
@@ -139,13 +143,14 @@ describe('YoutubeAtom', () => {
             />
         );
         const { getByTestId } = render(atom);
-        const overlay = getByTestId('youtube-overlay-ZCvZmYlQD8');
+        const overlay = getByTestId('youtube-overlay-ZCvZmYlQD8-xyz');
         expect(overlay).toBeInTheDocument();
     });
 
     it('hides an overlay once it is clicked', async () => {
         const atom = (
             <YoutubeAtom
+                id="xyz"
                 title="My Youtube video!"
                 assetId="ZCvZmYlQD8"
                 alt=""
@@ -158,10 +163,10 @@ describe('YoutubeAtom', () => {
             />
         );
         const { getByTestId } = render(atom);
-        const overlay = getByTestId('youtube-overlay-ZCvZmYlQD8');
+        const overlay = getByTestId('youtube-overlay-ZCvZmYlQD8-xyz');
         expect(overlay).toBeInTheDocument();
 
-        fireEvent.click(getByTestId('youtube-overlay-ZCvZmYlQD8'));
+        fireEvent.click(getByTestId('youtube-overlay-ZCvZmYlQD8-xyz'));
         expect(overlay).not.toBeInTheDocument();
     });
 
@@ -169,6 +174,7 @@ describe('YoutubeAtom', () => {
         const atom = (
             <>
                 <YoutubeAtom
+                    id="xyz"
                     title="My Youtube video!"
                     assetId="ZCvZmYlQD8"
                     alt=""
@@ -180,8 +186,9 @@ describe('YoutubeAtom', () => {
                     isMainMedia={false}
                 />
                 <YoutubeAtom
+                    id="xyz"
                     title="My Youtube video 2!"
-                    assetId="ZCvZmYlQD8-2"
+                    assetId="ZCvZmYlQD8_2"
                     alt=""
                     role="inline"
                     eventEmitters={[]}
@@ -193,13 +200,13 @@ describe('YoutubeAtom', () => {
             </>
         );
         const { getByTestId } = render(atom);
-        const overlay1 = getByTestId('youtube-overlay-ZCvZmYlQD8');
+        const overlay1 = getByTestId('youtube-overlay-ZCvZmYlQD8-xyz');
         expect(overlay1).toBeInTheDocument();
 
-        fireEvent.click(getByTestId('youtube-overlay-ZCvZmYlQD8'));
+        fireEvent.click(getByTestId('youtube-overlay-ZCvZmYlQD8-xyz'));
         expect(overlay1).not.toBeInTheDocument();
 
-        const overlay2 = getByTestId('youtube-overlay-ZCvZmYlQD8-2');
+        const overlay2 = getByTestId(`youtube-overlay-ZCvZmYlQD8_2-xyz`);
         expect(overlay2).toBeInTheDocument();
     });
 });

--- a/src/YoutubeAtom.test.tsx
+++ b/src/YoutubeAtom.test.tsx
@@ -222,6 +222,7 @@ describe('YoutubeAtom', () => {
                     eventEmitters={[]}
                     pillar={0}
                     overrideImage={overlayImage}
+                    shouldStick={false}
                 />
                 <YoutubeAtom
                     id="vwx"
@@ -232,6 +233,7 @@ describe('YoutubeAtom', () => {
                     eventEmitters={[]}
                     pillar={0}
                     overrideImage={overlayImage}
+                    shouldStick={false}
                 />
             </>
         );

--- a/src/YoutubeAtom.test.tsx
+++ b/src/YoutubeAtom.test.tsx
@@ -20,7 +20,7 @@ describe('YoutubeAtom', () => {
     it('Player initialises when no overlay and has consent state', async () => {
         const atom = (
             <YoutubeAtom
-                id="xyz"
+                elementId="xyz"
                 title="My Youtube video!"
                 videoId="ZCvZmYlQD8"
                 alt=""
@@ -40,7 +40,7 @@ describe('YoutubeAtom', () => {
     it('Player initialises when overlay clicked and has consent state', async () => {
         const atom = (
             <YoutubeAtom
-                id="xyz"
+                elementId="xyz"
                 title="My Youtube video!"
                 videoId="ZCvZmYlQD8"
                 alt=""
@@ -69,7 +69,7 @@ describe('YoutubeAtom', () => {
 
         const atom = (
             <YoutubeAtom
-                id="xyz"
+                elementId="xyz"
                 title="My Youtube video!"
                 videoId="ZCvZmYlQD8"
                 alt=""
@@ -90,7 +90,7 @@ describe('YoutubeAtom', () => {
         const title = 'My Youtube video!';
         const atom = (
             <YoutubeAtom
-                id="xyz"
+                elementId="xyz"
                 title="My Youtube video!"
                 videoId="ZCvZmYlQD8"
                 alt=""
@@ -113,7 +113,7 @@ describe('YoutubeAtom', () => {
     it('shows a placeholder if overlay is missing', async () => {
         const atom = (
             <YoutubeAtom
-                id="xyz"
+                elementId="xyz"
                 title="My Youtube video!"
                 videoId="ZCvZmYlQD8"
                 alt=""
@@ -132,7 +132,7 @@ describe('YoutubeAtom', () => {
     it('shows an overlay if present', async () => {
         const atom = (
             <YoutubeAtom
-                id="xyz"
+                elementId="xyz"
                 title="My Youtube video!"
                 videoId="ZCvZmYlQD8"
                 alt=""
@@ -152,7 +152,7 @@ describe('YoutubeAtom', () => {
     it('hides an overlay once it is clicked', async () => {
         const atom = (
             <YoutubeAtom
-                id="xyz"
+                elementId="xyz"
                 title="My Youtube video!"
                 videoId="ZCvZmYlQD8"
                 alt=""
@@ -176,7 +176,7 @@ describe('YoutubeAtom', () => {
         const atom = (
             <>
                 <YoutubeAtom
-                    id="xyz"
+                    elementId="xyz"
                     title="My Youtube video!"
                     videoId="ZCvZmYlQD8"
                     alt=""
@@ -188,7 +188,7 @@ describe('YoutubeAtom', () => {
                     isMainMedia={false}
                 />
                 <YoutubeAtom
-                    id="xyz"
+                    elementId="xyz"
                     title="My Youtube video 2!"
                     videoId="ZCvZmYlQD8_2"
                     alt=""

--- a/src/YoutubeAtom.test.tsx
+++ b/src/YoutubeAtom.test.tsx
@@ -69,6 +69,7 @@ describe('YoutubeAtom', () => {
 
         const atom = (
             <YoutubeAtom
+                id="xyz"
                 title="My Youtube video!"
                 assetId="ZCvZmYlQD8"
                 alt=""
@@ -81,14 +82,15 @@ describe('YoutubeAtom', () => {
             />
         );
         const { getByTestId } = render(atom);
-        const playerDiv = getByTestId('youtube-video-ZCvZmYlQD8');
+        const playerDiv = getByTestId('youtube-video-ZCvZmYlQD8-xyz');
         expect(playerDiv.title).toBe(title);
     });
 
-    it('overlay has correct aira-label', async () => {
+    it('overlay has correct aria-label', async () => {
         const title = 'My Youtube video!';
         const atom = (
             <YoutubeAtom
+                id="xyz"
                 title="My Youtube video!"
                 assetId="ZCvZmYlQD8"
                 alt=""
@@ -102,7 +104,7 @@ describe('YoutubeAtom', () => {
             />
         );
         const { getByTestId } = render(atom);
-        const overlay = getByTestId('youtube-overlay-ZCvZmYlQD8');
+        const overlay = getByTestId('youtube-overlay-ZCvZmYlQD8-xyz');
         const ariaLabel = overlay.getAttribute('aria-label');
 
         expect(ariaLabel).toBe(`Play video: ${title}`);
@@ -207,44 +209,6 @@ describe('YoutubeAtom', () => {
         expect(overlay1).not.toBeInTheDocument();
 
         const overlay2 = getByTestId(`youtube-overlay-ZCvZmYlQD8_2-xyz`);
-        expect(overlay2).toBeInTheDocument();
-    });
-
-    it('when two Atoms with duplicate videos - hides the overlay of the correct player if clicked', async () => {
-        const atom = (
-            <>
-                <YoutubeAtom
-                    id="xyz"
-                    title="My Youtube video!"
-                    assetId="ZCvZmYlQD8"
-                    alt=""
-                    role="inline"
-                    eventEmitters={[]}
-                    pillar={0}
-                    overrideImage={overlayImage}
-                    shouldStick={false}
-                />
-                <YoutubeAtom
-                    id="vwx"
-                    title="My Youtube video 2!"
-                    assetId="ZCvZmYlQD8"
-                    alt=""
-                    role="inline"
-                    eventEmitters={[]}
-                    pillar={0}
-                    overrideImage={overlayImage}
-                    shouldStick={false}
-                />
-            </>
-        );
-        const { getByTestId } = render(atom);
-        const overlay1 = getByTestId('youtube-overlay-ZCvZmYlQD8-xyz');
-        expect(overlay1).toBeInTheDocument();
-
-        fireEvent.click(getByTestId('youtube-overlay-ZCvZmYlQD8-xyz'));
-        expect(overlay1).not.toBeInTheDocument();
-
-        const overlay2 = getByTestId(`youtube-overlay-ZCvZmYlQD8-vwx`);
         expect(overlay2).toBeInTheDocument();
     });
 });

--- a/src/YoutubeAtom.test.tsx
+++ b/src/YoutubeAtom.test.tsx
@@ -209,4 +209,40 @@ describe('YoutubeAtom', () => {
         const overlay2 = getByTestId(`youtube-overlay-ZCvZmYlQD8_2-xyz`);
         expect(overlay2).toBeInTheDocument();
     });
+
+    it('when two Atoms with duplicate videos - hides the overlay of the correct player if clicked', async () => {
+        const atom = (
+            <>
+                <YoutubeAtom
+                    id="xyz"
+                    title="My Youtube video!"
+                    assetId="ZCvZmYlQD8"
+                    alt=""
+                    role="inline"
+                    eventEmitters={[]}
+                    pillar={0}
+                    overrideImage={overlayImage}
+                />
+                <YoutubeAtom
+                    id="vwx"
+                    title="My Youtube video 2!"
+                    assetId="ZCvZmYlQD8"
+                    alt=""
+                    role="inline"
+                    eventEmitters={[]}
+                    pillar={0}
+                    overrideImage={overlayImage}
+                />
+            </>
+        );
+        const { getByTestId } = render(atom);
+        const overlay1 = getByTestId('youtube-overlay-ZCvZmYlQD8-xyz');
+        expect(overlay1).toBeInTheDocument();
+
+        fireEvent.click(getByTestId('youtube-overlay-ZCvZmYlQD8-xyz'));
+        expect(overlay1).not.toBeInTheDocument();
+
+        const overlay2 = getByTestId(`youtube-overlay-ZCvZmYlQD8-vwx`);
+        expect(overlay2).toBeInTheDocument();
+    });
 });

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -57,6 +57,8 @@ export const YoutubeAtom = ({
     const [isPlaying, setIsPlaying] = useState<boolean>(false);
     const [stopVideo, setStopVideo] = useState<boolean>(false);
 
+    const uniqueId = `${videoId}-${elementId}`;
+
     /**
      * Update the isPlaying state based on video events
      *
@@ -134,8 +136,8 @@ export const YoutubeAtom = ({
             <MaintainAspectRatio height={height} width={width}>
                 {loadPlayer && consentState && (
                     <YoutubeAtomPlayer
-                        elementId={elementId}
                         videoId={videoId}
+                        uniqueId={uniqueId}
                         adTargeting={adTargeting}
                         consentState={consentState}
                         height={height}
@@ -154,8 +156,7 @@ export const YoutubeAtom = ({
                 )}
                 {showOverlay && (
                     <YoutubeAtomOverlay
-                        elementId={elementId}
-                        videoId={videoId}
+                        uniqueId={uniqueId}
                         overrideImage={overrideImage}
                         posterImage={posterImage}
                         height={height}
@@ -169,10 +170,7 @@ export const YoutubeAtom = ({
                     />
                 )}
                 {showPlaceholder && (
-                    <YoutubeAtomPlaceholder
-                        elementId={elementId}
-                        videoId={videoId}
-                    />
+                    <YoutubeAtomPlaceholder uniqueId={uniqueId} />
                 )}
             </MaintainAspectRatio>
         </YoutubeAtomSticky>

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -14,7 +14,7 @@ import type { ArticleTheme } from '@guardian/libs';
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
 
 type Props = {
-    id: string;
+    elementId: string;
     videoId: string;
     overrideImage?: ImageSource[];
     posterImage?: ImageSource[];
@@ -34,7 +34,7 @@ type Props = {
 };
 
 export const YoutubeAtom = ({
-    id,
+    elementId,
     videoId,
     overrideImage,
     posterImage,
@@ -134,7 +134,7 @@ export const YoutubeAtom = ({
             <MaintainAspectRatio height={height} width={width}>
                 {loadPlayer && consentState && (
                     <YoutubeAtomPlayer
-                        id={id}
+                        elementId={elementId}
                         videoId={videoId}
                         adTargeting={adTargeting}
                         consentState={consentState}
@@ -154,7 +154,7 @@ export const YoutubeAtom = ({
                 )}
                 {showOverlay && (
                     <YoutubeAtomOverlay
-                        id={id}
+                        elementId={elementId}
                         videoId={videoId}
                         overrideImage={overrideImage}
                         posterImage={posterImage}
@@ -169,7 +169,10 @@ export const YoutubeAtom = ({
                     />
                 )}
                 {showPlaceholder && (
-                    <YoutubeAtomPlaceholder id={id} videoId={videoId} />
+                    <YoutubeAtomPlaceholder
+                        elementId={elementId}
+                        videoId={videoId}
+                    />
                 )}
             </MaintainAspectRatio>
         </YoutubeAtomSticky>

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -14,6 +14,7 @@ import type { ArticleTheme } from '@guardian/libs';
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
 
 type Props = {
+    id: string;
     assetId: string;
     overrideImage?: ImageSource[];
     posterImage?: ImageSource[];
@@ -33,6 +34,7 @@ type Props = {
 };
 
 export const YoutubeAtom = ({
+    id,
     assetId,
     overrideImage,
     posterImage,
@@ -132,6 +134,7 @@ export const YoutubeAtom = ({
             <MaintainAspectRatio height={height} width={width}>
                 {loadPlayer && consentState && (
                     <YoutubeAtomPlayer
+                        id={id}
                         videoId={assetId}
                         adTargeting={adTargeting}
                         consentState={consentState}
@@ -151,6 +154,7 @@ export const YoutubeAtom = ({
                 )}
                 {showOverlay && (
                     <YoutubeAtomOverlay
+                        id={id}
                         videoId={assetId}
                         overrideImage={overrideImage}
                         posterImage={posterImage}
@@ -165,7 +169,7 @@ export const YoutubeAtom = ({
                     />
                 )}
                 {showPlaceholder && (
-                    <YoutubeAtomPlaceholder videoId={assetId} />
+                    <YoutubeAtomPlaceholder id={id} videoId={assetId} />
                 )}
             </MaintainAspectRatio>
         </YoutubeAtomSticky>

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -15,7 +15,7 @@ import type { ConsentState } from '@guardian/consent-management-platform/dist/ty
 
 type Props = {
     id: string;
-    assetId: string;
+    videoId: string;
     overrideImage?: ImageSource[];
     posterImage?: ImageSource[];
     adTargeting?: AdTargeting;
@@ -35,7 +35,7 @@ type Props = {
 
 export const YoutubeAtom = ({
     id,
-    assetId,
+    videoId,
     overrideImage,
     posterImage,
     adTargeting,
@@ -124,7 +124,7 @@ export const YoutubeAtom = ({
 
     return (
         <YoutubeAtomSticky
-            assetId={assetId}
+            videoId={videoId}
             shouldStick={shouldStick}
             isPlaying={isPlaying}
             eventEmitters={eventEmitters}
@@ -135,7 +135,7 @@ export const YoutubeAtom = ({
                 {loadPlayer && consentState && (
                     <YoutubeAtomPlayer
                         id={id}
-                        videoId={assetId}
+                        videoId={videoId}
                         adTargeting={adTargeting}
                         consentState={consentState}
                         height={height}
@@ -155,7 +155,7 @@ export const YoutubeAtom = ({
                 {showOverlay && (
                     <YoutubeAtomOverlay
                         id={id}
-                        videoId={assetId}
+                        videoId={videoId}
                         overrideImage={overrideImage}
                         posterImage={posterImage}
                         height={height}
@@ -169,7 +169,7 @@ export const YoutubeAtom = ({
                     />
                 )}
                 {showPlaceholder && (
-                    <YoutubeAtomPlaceholder id={id} videoId={assetId} />
+                    <YoutubeAtomPlaceholder id={id} videoId={videoId} />
                 )}
             </MaintainAspectRatio>
         </YoutubeAtomSticky>

--- a/src/YoutubeAtomOverlay.tsx
+++ b/src/YoutubeAtomOverlay.tsx
@@ -16,8 +16,7 @@ import { ImageSource, RoleType } from './types';
 import type { ArticleTheme } from '@guardian/libs';
 
 type Props = {
-    elementId: string;
-    videoId: string;
+    uniqueId: string;
     overrideImage?: ImageSource[];
     posterImage?: ImageSource[];
     height: number;
@@ -99,8 +98,7 @@ const videoDurationStyles = (pillar: ArticleTheme) => css`
 `;
 
 export const YoutubeAtomOverlay = ({
-    elementId,
-    videoId,
+    uniqueId,
     overrideImage,
     posterImage,
     height,
@@ -112,11 +110,11 @@ export const YoutubeAtomOverlay = ({
     title,
     onClick,
 }: Props): JSX.Element => {
-    const uniqueId = `youtube-overlay-${videoId}-${elementId}`;
+    const id = `youtube-overlay-${uniqueId}`;
     return (
         <button
-            data-cy={uniqueId}
-            data-testid={uniqueId}
+            data-cy={id}
+            data-testid={id}
             onClick={onClick}
             css={overlayStyles}
             aria-label={`Play video: ${title}`}

--- a/src/YoutubeAtomOverlay.tsx
+++ b/src/YoutubeAtomOverlay.tsx
@@ -16,7 +16,7 @@ import { ImageSource, RoleType } from './types';
 import type { ArticleTheme } from '@guardian/libs';
 
 type Props = {
-    id: string;
+    elementId: string;
     videoId: string;
     overrideImage?: ImageSource[];
     posterImage?: ImageSource[];
@@ -99,7 +99,7 @@ const videoDurationStyles = (pillar: ArticleTheme) => css`
 `;
 
 export const YoutubeAtomOverlay = ({
-    id,
+    elementId,
     videoId,
     overrideImage,
     posterImage,
@@ -112,7 +112,7 @@ export const YoutubeAtomOverlay = ({
     title,
     onClick,
 }: Props): JSX.Element => {
-    const uniqueId = `youtube-overlay-${videoId}-${id}`;
+    const uniqueId = `youtube-overlay-${videoId}-${elementId}`;
     return (
         <button
             data-cy={uniqueId}

--- a/src/YoutubeAtomOverlay.tsx
+++ b/src/YoutubeAtomOverlay.tsx
@@ -16,6 +16,7 @@ import { ImageSource, RoleType } from './types';
 import type { ArticleTheme } from '@guardian/libs';
 
 type Props = {
+    id: string;
     videoId: string;
     overrideImage?: ImageSource[];
     posterImage?: ImageSource[];
@@ -98,6 +99,7 @@ const videoDurationStyles = (pillar: ArticleTheme) => css`
 `;
 
 export const YoutubeAtomOverlay = ({
+    id,
     videoId,
     overrideImage,
     posterImage,
@@ -110,10 +112,11 @@ export const YoutubeAtomOverlay = ({
     title,
     onClick,
 }: Props): JSX.Element => {
+    const uniqueId = `youtube-overlay-${videoId}-${id}`;
     return (
         <button
-            data-cy={`youtube-overlay-${videoId}`}
-            data-testid={`youtube-overlay-${videoId}`}
+            data-cy={uniqueId}
+            data-testid={uniqueId}
             onClick={onClick}
             css={overlayStyles}
             aria-label={`Play video: ${title}`}

--- a/src/YoutubeAtomPlaceholder.tsx
+++ b/src/YoutubeAtomPlaceholder.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { css } from '@emotion/react';
 
 export const YoutubeAtomPlaceholder = ({
-    id,
+    elementId,
     videoId,
 }: {
-    id: string;
+    elementId: string;
     videoId: string;
 }): JSX.Element => {
-    const uniqueId = `youtube-placeholder-${videoId}-${id}`;
+    const uniqueId = `youtube-placeholder-${videoId}-${elementId}`;
     return (
         <div
             data-name={uniqueId}

--- a/src/YoutubeAtomPlaceholder.tsx
+++ b/src/YoutubeAtomPlaceholder.tsx
@@ -2,17 +2,15 @@ import React from 'react';
 import { css } from '@emotion/react';
 
 export const YoutubeAtomPlaceholder = ({
-    elementId,
-    videoId,
+    uniqueId,
 }: {
-    elementId: string;
-    videoId: string;
+    uniqueId: string;
 }): JSX.Element => {
-    const uniqueId = `youtube-placeholder-${videoId}-${elementId}`;
+    const id = `youtube-placeholder-${uniqueId}`;
     return (
         <div
-            data-name={uniqueId}
-            data-testid={uniqueId}
+            data-name={id}
+            data-testid={id}
             css={[
                 css`
                     width: 100%;

--- a/src/YoutubeAtomPlaceholder.tsx
+++ b/src/YoutubeAtomPlaceholder.tsx
@@ -2,14 +2,17 @@ import React from 'react';
 import { css } from '@emotion/react';
 
 export const YoutubeAtomPlaceholder = ({
+    id,
     videoId,
 }: {
+    id: string;
     videoId: string;
 }): JSX.Element => {
+    const uniqueId = `youtube-placeholder-${videoId}-${id}`;
     return (
         <div
-            data-name={`youtube-placeholder-${videoId}`}
-            data-testid={`youtube-placeholder-${videoId}`}
+            data-name={uniqueId}
+            data-testid={uniqueId}
             css={[
                 css`
                     width: 100%;

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -11,7 +11,7 @@ import {
 import { log } from '@guardian/libs';
 
 type Props = {
-    id: string;
+    elementId: string;
     videoId: string;
     adTargeting?: AdTargeting;
     consentState: ConsentState;
@@ -195,7 +195,7 @@ const createOnStateChangeListener = (
 };
 
 export const YoutubeAtomPlayer = ({
-    id,
+    elementId,
     videoId,
     adTargeting,
     consentState,
@@ -222,7 +222,7 @@ export const YoutubeAtomPlayer = ({
         hasSentEndEvent: false,
     });
     const listeners = useRef<Array<YoutubeCallback>>([]);
-    const uniqueId = `youtube-video-${videoId}-${id}`;
+    const uniqueId = `youtube-video-${videoId}-${elementId}`;
 
     /**
      * Initialise player useEffect

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -11,7 +11,7 @@ import {
 import { log } from '@guardian/libs';
 
 type Props = {
-    elementId: string;
+    uniqueId: string;
     videoId: string;
     adTargeting?: AdTargeting;
     consentState: ConsentState;
@@ -195,7 +195,7 @@ const createOnStateChangeListener = (
 };
 
 export const YoutubeAtomPlayer = ({
-    elementId,
+    uniqueId,
     videoId,
     adTargeting,
     consentState,
@@ -222,7 +222,7 @@ export const YoutubeAtomPlayer = ({
         hasSentEndEvent: false,
     });
     const listeners = useRef<Array<YoutubeCallback>>([]);
-    const uniqueId = `youtube-video-${videoId}-${elementId}`;
+    const id = `youtube-video-${uniqueId}`;
 
     /**
      * Initialise player useEffect
@@ -250,7 +250,7 @@ export const YoutubeAtomPlayer = ({
                  * It will load the iframe embed
                  * It's API allows us to queue up calls to YT that will fire when the underlying player is ready
                  */
-                player.current = YouTubePlayer(uniqueId, {
+                player.current = YouTubePlayer(id, {
                     height: width,
                     width: height,
                     videoId,
@@ -380,9 +380,9 @@ export const YoutubeAtomPlayer = ({
      */
     return (
         <div
-            id={uniqueId}
-            data-atom-id={uniqueId}
-            data-testid={uniqueId}
+            id={id}
+            data-atom-id={id}
+            data-testid={id}
             data-atom-type="youtube"
             title={title}
         ></div>

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -11,6 +11,7 @@ import {
 import { log } from '@guardian/libs';
 
 type Props = {
+    id: string;
     videoId: string;
     adTargeting?: AdTargeting;
     consentState: ConsentState;
@@ -194,6 +195,7 @@ const createOnStateChangeListener = (
 };
 
 export const YoutubeAtomPlayer = ({
+    id,
     videoId,
     adTargeting,
     consentState,
@@ -220,6 +222,7 @@ export const YoutubeAtomPlayer = ({
         hasSentEndEvent: false,
     });
     const listeners = useRef<Array<YoutubeCallback>>([]);
+    const uniqueId = `youtube-video-${videoId}-${id}`;
 
     /**
      * Initialise player useEffect
@@ -247,7 +250,7 @@ export const YoutubeAtomPlayer = ({
                  * It will load the iframe embed
                  * It's API allows us to queue up calls to YT that will fire when the underlying player is ready
                  */
-                player.current = YouTubePlayer(`youtube-video-${videoId}`, {
+                player.current = YouTubePlayer(uniqueId, {
                     height: width,
                     width: height,
                     videoId,
@@ -377,11 +380,11 @@ export const YoutubeAtomPlayer = ({
      */
     return (
         <div
-            title={title}
-            id={`youtube-video-${videoId}`}
-            data-atom-id={`youtube-video-${videoId}`}
-            data-testid={`youtube-video-${videoId}`}
+            id={uniqueId}
+            data-atom-id={uniqueId}
+            data-testid={uniqueId}
             data-atom-type="youtube"
+            title={title}
         ></div>
     );
 };

--- a/src/YoutubeAtomSticky.tsx
+++ b/src/YoutubeAtomSticky.tsx
@@ -94,7 +94,7 @@ const stickyContainerStyles = (isMainMedia?: boolean) => {
 };
 
 type Props = {
-    assetId: string;
+    videoId: string;
     eventEmitters: ((event: VideoEventKey) => void)[];
     shouldStick?: boolean;
     onStopVideo: () => void;
@@ -104,7 +104,7 @@ type Props = {
 };
 
 export const YoutubeAtomSticky = ({
-    assetId,
+    videoId,
     eventEmitters,
     shouldStick,
     onStopVideo,
@@ -134,7 +134,7 @@ export const YoutubeAtomSticky = ({
         // emit a 'close' event
         log('dotcom', {
             from: `YoutubeAtom handleCloseClick`,
-            videoId: assetId,
+            videoId,
             msg: 'Close',
         });
         eventEmitters.forEach((eventEmitter) => eventEmitter('close'));
@@ -176,12 +176,12 @@ export const YoutubeAtomSticky = ({
 
             log('dotcom', {
                 from: 'YoutubeAtom stick useEffect',
-                videoId: assetId,
+                videoId,
                 msg: 'Stick',
             });
             eventEmitters.forEach((eventEmitter) => eventEmitter('stick'));
         }
-    }, [isSticky, stickEventSent, assetId, eventEmitters]);
+    }, [isSticky, stickEventSent, videoId, eventEmitters]);
 
     return (
         <div ref={setRef} css={isSticky && stickyContainerStyles(isMainMedia)}>


### PR DESCRIPTION
## What does this change?

Fixes a bug when we have duplicate videos on the same page.

This issue is more apparent on liveblogs where the same video can be in the main media position and in a block.

This is the corresponding DCR fix to the Frontend fix: https://github.com/guardian/frontend/pull/24713

### Bug

Currently we use the `videoId` for the YouTubeAtom component ids e.g. :

`<div id="youtube-player-${videoId} ...>`

This is not unique when there are multiple instances of the same video and hence the YouTube player will not mount duplicate instances.

### Fix

The fix is to combine `elementId` as provided by `DotcomRenderingDataModel` e.g. :

`<div id="youtube-player-${videoId}-${elementId} ...>`

With this the YouTube player can correctly select and mount each video instance.

### elementId

Expects `elementId` to be passed from DCR as detailed here:
https://github.com/guardian/frontend/blob/f4c8237babfa16b6efe33006a55084dbf06fe462/common/app/model/dotcomrendering/PageElement-Identifiers.md

Example `DotcomRenderingDataModel` output with generated `elementId`s (search for `YoutubeBlockElement `):
https://www.theguardian.com/media/2021/jun/25/guardian-journalists-win-orwell-prize-for-video-series-anywhere-but-westminster-john-harris-john-domokos.json?dcr=true

## Images

| Before      | After |
| ----------- | ----------- |
|   ![Screenshot 2022-03-24 at 11 24 08](https://user-images.githubusercontent.com/7014230/159906969-fdc1b292-11fe-488d-a249-01ecd430db90.png) | ![Screenshot 2022-03-24 at 11 24 55](https://user-images.githubusercontent.com/7014230/159907000-050ff3d3-f968-47cb-a284-86af6d9c93b4.png) |

