### PR TITLE
Add isMainMedia prop to `YoutubeAtom`

### DIFF
--- a/.changeset/smart-apes-shake.md
+++ b/.changeset/smart-apes-shake.md
@@ -1,0 +1,5 @@
+---
+'@guardian/atoms-rendering': patch
+---
+
+Add isMainMedia prop to YoutubeAtom

--- a/src/YoutubeAtom.stories.tsx
+++ b/src/YoutubeAtom.stories.tsx
@@ -29,6 +29,7 @@ export const NoConsent = (): JSX.Element => {
                 height={450}
                 width={800}
                 shouldStick={false}
+                isMainMedia={false}
             />
         </div>
     );
@@ -55,6 +56,7 @@ export const NoOverlay = (): JSX.Element => {
                 height={450}
                 width={800}
                 shouldStick={false}
+                isMainMedia={false}
             />
         </div>
     );
@@ -90,6 +92,7 @@ export const WithOverrideImage = (): JSX.Element => {
                     },
                 ]}
                 shouldStick={false}
+                isMainMedia={false}
             />
         </div>
     );
@@ -142,6 +145,7 @@ export const WithPosterImage = (): JSX.Element => {
                 height={450}
                 width={800}
                 shouldStick={false}
+                isMainMedia={false}
             />
         </div>
     );
@@ -205,6 +209,7 @@ export const WithOverlayAndPosterImage = (): JSX.Element => {
                 height={450}
                 width={800}
                 shouldStick={false}
+                isMainMedia={false}
             />
         </div>
     );
@@ -245,6 +250,7 @@ export const GiveConsent = (): JSX.Element => {
                     height={450}
                     width={800}
                     shouldStick={false}
+                    isMainMedia={false}
                 />
             </div>
         </>
@@ -268,6 +274,31 @@ export const Sticky = (): JSX.Element => {
                 height={450}
                 width={800}
                 shouldStick={true}
+                isMainMedia={true}
+            />
+            <div style={{ height: '1000px' }}></div>
+        </div>
+    );
+};
+
+export const StickyMainMedia = (): JSX.Element => {
+    return (
+        <div>
+            <div style={{ height: '1000px' }}></div>
+            <YoutubeAtom
+                assetId="-ZCvZmYlQD8"
+                alt=""
+                role="inline"
+                eventEmitters={[
+                    (e) => console.log(`analytics event ${e} called`),
+                ]}
+                consentState={{}}
+                duration={252}
+                pillar={ArticlePillar.Culture}
+                height={450}
+                width={800}
+                shouldStick={true}
+                isMainMedia={true}
             />
             <div style={{ height: '1000px' }}></div>
         </div>

--- a/src/YoutubeAtom.test.tsx
+++ b/src/YoutubeAtom.test.tsx
@@ -27,6 +27,8 @@ describe('YoutubeAtom', () => {
                 eventEmitters={[]}
                 pillar={0}
                 consentState={{}}
+                shouldStick={false}
+                mainMedia={false}
             />
         );
         const { getByTestId } = render(atom);
@@ -45,6 +47,8 @@ describe('YoutubeAtom', () => {
                 pillar={0}
                 consentState={{}}
                 overrideImage={overlayImage}
+                shouldStick={false}
+                mainMedia={false}
             />
         );
         const { getByTestId } = render(atom);
@@ -67,6 +71,8 @@ describe('YoutubeAtom', () => {
                 role="inline"
                 eventEmitters={[]}
                 pillar={0}
+                shouldStick={false}
+                mainMedia={false}
             />
         );
         const { getByTestId } = render(atom);
@@ -84,6 +90,8 @@ describe('YoutubeAtom', () => {
                 eventEmitters={[]}
                 pillar={0}
                 overrideImage={overlayImage}
+                shouldStick={false}
+                mainMedia={false}
             />
         );
         const { getByTestId } = render(atom);
@@ -101,6 +109,8 @@ describe('YoutubeAtom', () => {
                 eventEmitters={[]}
                 pillar={0}
                 overrideImage={overlayImage}
+                shouldStick={false}
+                mainMedia={false}
             />
         );
         const { getByTestId } = render(atom);
@@ -122,6 +132,8 @@ describe('YoutubeAtom', () => {
                     eventEmitters={[]}
                     pillar={0}
                     overrideImage={overlayImage}
+                    shouldStick={false}
+                    mainMedia={false}
                 />
                 <YoutubeAtom
                     title="My Youtube video 2!"
@@ -131,6 +143,8 @@ describe('YoutubeAtom', () => {
                     eventEmitters={[]}
                     pillar={0}
                     overrideImage={overlayImage}
+                    shouldStick={false}
+                    mainMedia={false}
                 />
             </>
         );

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -28,7 +28,8 @@ type Props = {
     origin?: string;
     eventEmitters: ((event: VideoEventKey) => void)[];
     pillar: ArticleTheme;
-    shouldStick: boolean;
+    shouldStick?: boolean;
+    isMainMedia?: boolean;
 };
 
 export const YoutubeAtom = ({
@@ -47,6 +48,7 @@ export const YoutubeAtom = ({
     eventEmitters,
     pillar,
     shouldStick,
+    isMainMedia,
 }: Props): JSX.Element => {
     const [overlayClicked, setOverlayClicked] = useState<boolean>(false);
     const [playerReady, setPlayerReady] = useState<boolean>(false);
@@ -123,6 +125,7 @@ export const YoutubeAtom = ({
             isPlaying={isPlaying}
             eventEmitters={eventEmitters}
             onStopVideo={() => setStopVideo(true)}
+            isMainMedia={isMainMedia}
         >
             <MaintainAspectRatio height={height} width={width}>
                 {loadPlayer && consentState && (

--- a/src/YoutubeAtomSticky.tsx
+++ b/src/YoutubeAtomSticky.tsx
@@ -79,23 +79,29 @@ const stickyStyles = css`
     }
 `;
 
-const stickyContainerStyles = (height: number) => css`
-    height: ${height}px;
-    position: relative;
-    display: flex;
-    justify-content: flex-end;
+const stickyContainerStyles = (isMainMedia?: boolean) => {
+    const height = 192;
 
-    ${from.tablet} {
-        height: ${height * 2}px;
-    }
-`;
+    return css`
+        height: ${height}px;
+        position: relative;
+        display: flex;
+        justify-content: flex-end;
+        padding-right: ${isMainMedia ? '20px' : 0};
+
+        ${from.tablet} {
+            height: ${height * 2}px;
+        }
+    `;
+};
 
 type Props = {
     assetId: string;
     eventEmitters: ((event: VideoEventKey) => void)[];
-    shouldStick: boolean;
+    shouldStick?: boolean;
     onStopVideo: () => void;
     isPlaying: boolean;
+    isMainMedia?: boolean;
     children: JSX.Element;
 };
 
@@ -105,6 +111,7 @@ export const YoutubeAtomSticky = ({
     shouldStick,
     onStopVideo,
     isPlaying,
+    isMainMedia,
     children,
 }: Props): JSX.Element => {
     const [isSticky, setIsSticky] = useState<boolean>(false);
@@ -159,7 +166,7 @@ export const YoutubeAtomSticky = ({
     }, [isSticky, stickEventSent, assetId, eventEmitters]);
 
     return (
-        <div ref={setRef} css={isSticky && stickyContainerStyles(192)}>
+        <div ref={setRef} css={isSticky && stickyContainerStyles(isMainMedia)}>
             <div css={isSticky && stickyStyles}>
                 {children}
                 {isSticky && (

--- a/src/YoutubeAtomSticky.tsx
+++ b/src/YoutubeAtomSticky.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import type { VideoEventKey } from './types';
 import { log } from '@guardian/libs';
 import { useIsInView } from './lib/useIsInView';
-import { from, neutral } from '@guardian/source-foundations';
+import { from, neutral, space } from '@guardian/source-foundations';
 import { css } from '@emotion/react';
 import { SvgCross } from '@guardian/source-react-components';
 
@@ -87,7 +87,7 @@ const stickyContainerStyles = (isMainMedia?: boolean) => {
         position: relative;
         display: flex;
         justify-content: flex-end;
-        padding-right: ${isMainMedia ? '20px' : 0};
+        padding-right: ${isMainMedia ? `${space[5]}px` : 0};
 
         ${from.tablet} {
             height: ${height * 2}px;


### PR DESCRIPTION
## What does this change?

Adds an `isMainMedia` prop to the `YoutubeAtom` which is in turn passed to the `YoutubeAtomSticky` component, allowing us to adjust the sticky videos position for main media videos.

Currently the sticky video aligns with the right hand margin of its original container, if this a main media video we need to add `20px` padding right.

The DCR PR to implement these changes once the new version of Atoms Rendering is released [is here](https://github.com/guardian/dotcom-rendering/pull/4426).

### Details

- added `isMainMedia` prop
- tidied up `stickyContainerStyles`
- made `shouldStick` prop optional for consistency in DCR

### Before
<img width="300" alt="Screenshot 2022-03-28 at 10 06 01" src="https://user-images.githubusercontent.com/77005274/160364892-55716679-7a91-4aa9-9336-950e306a5c27.png">

### After

<img width="300" alt="Screenshot 2022-03-28 at 10 04 55" src="https://user-images.githubusercontent.com/77005274/160364932-d149291e-6c5d-4c3d-8934-d88e7ae9fba0.png">

