### PR TITLE
Correct "mainMedia" to "isMainMedia" in `YoutubeAtom` tests

### DIFF
--- a/src/YoutubeAtom.test.tsx
+++ b/src/YoutubeAtom.test.tsx
@@ -28,7 +28,7 @@ describe('YoutubeAtom', () => {
                 pillar={0}
                 consentState={{}}
                 shouldStick={false}
-                mainMedia={false}
+                isMainMedia={false}
             />
         );
         const { getByTestId } = render(atom);
@@ -48,7 +48,7 @@ describe('YoutubeAtom', () => {
                 consentState={{}}
                 overrideImage={overlayImage}
                 shouldStick={false}
-                mainMedia={false}
+                isMainMedia={false}
             />
         );
         const { getByTestId } = render(atom);
@@ -72,7 +72,7 @@ describe('YoutubeAtom', () => {
                 eventEmitters={[]}
                 pillar={0}
                 shouldStick={false}
-                mainMedia={false}
+                isMainMedia={false}
             />
         );
         const { getByTestId } = render(atom);
@@ -91,7 +91,7 @@ describe('YoutubeAtom', () => {
                 pillar={0}
                 overrideImage={overlayImage}
                 shouldStick={false}
-                mainMedia={false}
+                isMainMedia={false}
             />
         );
         const { getByTestId } = render(atom);
@@ -110,7 +110,7 @@ describe('YoutubeAtom', () => {
                 pillar={0}
                 overrideImage={overlayImage}
                 shouldStick={false}
-                mainMedia={false}
+                isMainMedia={false}
             />
         );
         const { getByTestId } = render(atom);
@@ -133,7 +133,7 @@ describe('YoutubeAtom', () => {
                     pillar={0}
                     overrideImage={overlayImage}
                     shouldStick={false}
-                    mainMedia={false}
+                    isMainMedia={false}
                 />
                 <YoutubeAtom
                     title="My Youtube video 2!"
@@ -144,7 +144,7 @@ describe('YoutubeAtom', () => {
                     pillar={0}
                     overrideImage={overlayImage}
                     shouldStick={false}
-                    mainMedia={false}
+                    isMainMedia={false}
                 />
             </>
         );


### PR DESCRIPTION
## What does this change?

Corrects an incorrect prop name in the `YoutubeAtom` tests. This sneaked in as part of [this PR](https://github.com/guardian/atoms-rendering/pull/367/files).
