### PR TITLE
Fix `YoutubeAtom` tabbing issues

### DIFF
--- a/.changeset/neat-bees-suffer.md
+++ b/.changeset/neat-bees-suffer.md
@@ -1,0 +1,5 @@
+---
+'@guardian/atoms-rendering': patch
+---
+
+Make YoutubeAtom controls keyboard accesible

--- a/src/Picture.tsx
+++ b/src/Picture.tsx
@@ -8,8 +8,8 @@ type Props = {
     imageSources: ImageSource[];
     role: RoleType;
     alt: string;
-    height: string;
-    width: string;
+    height: number;
+    width: number;
     isMainMedia?: boolean;
     isLazy?: boolean;
 };

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -131,8 +131,6 @@ export const YoutubeAtom = ({
                 {loadPlayer && consentState && (
                     <YoutubeAtomPlayer
                         videoId={assetId}
-                        overrideImage={overrideImage}
-                        posterImage={posterImage}
                         adTargeting={adTargeting}
                         consentState={consentState}
                         height={height}

--- a/src/YoutubeAtomOverlay.tsx
+++ b/src/YoutubeAtomOverlay.tsx
@@ -38,6 +38,8 @@ const overlayStyles = css`
     position: absolute;
     max-height: 100vh;
     cursor: pointer;
+    border: 0;
+    padding: 0;
 
     img {
         width: 100%;
@@ -107,26 +109,18 @@ export const YoutubeAtomOverlay = ({
     onClick,
 }: Props): JSX.Element => {
     return (
-        <div
+        <button
             data-cy={`youtube-overlay-${videoId}`}
             data-testid={`youtube-overlay-${videoId}`}
-            onClick={() => {
-                onClick();
-            }}
-            onKeyDown={(e) => {
-                if (e.code === 'Space' || e.code === 'Enter') {
-                    onClick();
-                }
-            }}
+            onClick={onClick}
             css={overlayStyles}
-            tabIndex={0}
         >
             <Picture
                 imageSources={overrideImage || posterImage || []}
                 role={role}
                 alt={alt}
-                height={`${height}`}
-                width={`${width}`}
+                height={height}
+                width={width}
             />
             <div css={overlayInfoWrapperStyles}>
                 <div
@@ -143,6 +137,6 @@ export const YoutubeAtomOverlay = ({
                     </div>
                 )}
             </div>
-        </div>
+        </button>
     );
 };

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import YouTubePlayer from 'youtube-player';
 
-import type { AdTargeting, ImageSource, VideoEventKey } from './types';
+import type { AdTargeting, VideoEventKey } from './types';
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
 import {
     AdsConfig,
@@ -12,8 +12,6 @@ import { log } from '@guardian/libs';
 
 type Props = {
     videoId: string;
-    overrideImage?: ImageSource[];
-    posterImage?: ImageSource[];
     adTargeting?: AdTargeting;
     consentState: ConsentState;
     height: number;
@@ -178,8 +176,6 @@ const createOnStateChangeListener = (
 
 export const YoutubeAtomPlayer = ({
     videoId,
-    overrideImage,
-    posterImage,
     adTargeting,
     consentState,
     height,
@@ -363,7 +359,6 @@ export const YoutubeAtomPlayer = ({
         <div
             title={title}
             id={`youtube-video-${videoId}`}
-            tabIndex={overrideImage || posterImage ? -1 : 0}
             data-atom-id={`youtube-video-${videoId}`}
             data-testid={`youtube-video-${videoId}`}
             data-atom-type="youtube"


### PR DESCRIPTION
## What does this change?

As part of the sticky videos work, and recently highlighted by the DAC reports, we've become aware that YoutubeAtom's were difficult to use with keyboard only navigation.

This PR removes the `tabIndex` values, and makes the overlay component a `button` rather than a `div`. The result is an atom which is much easier to navigate using keyboard controls.


DAC issues:


[Active elements were found that could not be navigated to via the keyboard.](https://drive.google.com/file/d/1S8ElKJj6sRNrEu5zQNp6fGejocXKgUM-/view
)
[Missing focus indicator](https://drive.google.com/file/d/1-aPrCLPJm-7lqiwrSwyfRc1BfP138YIa/view
)

## How to test

Go to storybook `YoutubeAtom/Overlay`, tab into the component and use `enter` to start the video. The controls should be available by keyboard navigation.


## Before

https://user-images.githubusercontent.com/77005274/160433223-1f50d2ef-e127-42c7-a06d-4ac6e751b669.mov


## After


https://user-images.githubusercontent.com/77005274/160433137-95988ac3-3f34-45cd-94f4-955d02a245c3.mov


