### PR TITLE
Add title to `YoutubeAtom` button label and iframe

### DIFF
--- a/.changeset/six-tables-retire.md
+++ b/.changeset/six-tables-retire.md
@@ -1,0 +1,5 @@
+---
+'@guardian/atoms-rendering': patch
+---
+
+Add title to YoutubeAtom iframe and aria-label

--- a/src/YoutubeAtom.stories.tsx
+++ b/src/YoutubeAtom.stories.tsx
@@ -57,6 +57,7 @@ export const NoOverlay = (): JSX.Element => {
                 width={800}
                 shouldStick={false}
                 isMainMedia={false}
+                title="Rayshard Brooks: US justice system treats us like 'animals'"
             />
         </div>
     );
@@ -93,6 +94,7 @@ export const WithOverrideImage = (): JSX.Element => {
                 ]}
                 shouldStick={false}
                 isMainMedia={false}
+                title="How to stop the spread of coronavirus"
             />
         </div>
     );
@@ -146,6 +148,7 @@ export const WithPosterImage = (): JSX.Element => {
                 width={800}
                 shouldStick={false}
                 isMainMedia={false}
+                title="How Donald Trump’s broken promises failed Ohio | Anywhere but Washington"
             />
         </div>
     );
@@ -210,6 +213,7 @@ export const WithOverlayAndPosterImage = (): JSX.Element => {
                 width={800}
                 shouldStick={false}
                 isMainMedia={false}
+                title="How Donald Trump’s broken promises failed Ohio"
             />
         </div>
     );
@@ -251,6 +255,7 @@ export const GiveConsent = (): JSX.Element => {
                     width={800}
                     shouldStick={false}
                     isMainMedia={false}
+                    title="How to stop the spread of coronavirus"
                 />
             </div>
         </>
@@ -275,6 +280,7 @@ export const Sticky = (): JSX.Element => {
                 width={800}
                 shouldStick={true}
                 isMainMedia={true}
+                title="Rayshard Brooks: US justice system treats us like 'animals'"
             />
             <div style={{ height: '1000px' }}></div>
         </div>
@@ -299,6 +305,7 @@ export const StickyMainMedia = (): JSX.Element => {
                 width={800}
                 shouldStick={true}
                 isMainMedia={true}
+                title="Rayshard Brooks: US justice system treats us like 'animals'"
             />
             <div style={{ height: '1000px' }}></div>
         </div>

--- a/src/YoutubeAtom.test.tsx
+++ b/src/YoutubeAtom.test.tsx
@@ -28,7 +28,7 @@ describe('YoutubeAtom', () => {
                 pillar={0}
                 consentState={{}}
                 shouldStick={false}
-                mainMedia={false}
+                isMainMedia={false}
             />
         );
         const { getByTestId } = render(atom);
@@ -48,7 +48,7 @@ describe('YoutubeAtom', () => {
                 consentState={{}}
                 overrideImage={overlayImage}
                 shouldStick={false}
-                mainMedia={false}
+                isMainMedia={false}
             />
         );
         const { getByTestId } = render(atom);
@@ -62,6 +62,50 @@ describe('YoutubeAtom', () => {
         expect(playerDiv).toBeInTheDocument();
     });
 
+    it('player div has correct title', async () => {
+        const title = 'My Youtube video!';
+
+        const atom = (
+            <YoutubeAtom
+                title="My Youtube video!"
+                assetId="ZCvZmYlQD8"
+                alt=""
+                role="inline"
+                eventEmitters={[]}
+                pillar={0}
+                consentState={{}}
+                shouldStick={false}
+                isMainMedia={false}
+            />
+        );
+        const { getByTestId } = render(atom);
+        const playerDiv = getByTestId('youtube-video-ZCvZmYlQD8');
+        expect(playerDiv.title).toBe(title);
+    });
+
+    it('overlay has correct aira-label', async () => {
+        const title = 'My Youtube video!';
+        const atom = (
+            <YoutubeAtom
+                title="My Youtube video!"
+                assetId="ZCvZmYlQD8"
+                alt=""
+                role="inline"
+                eventEmitters={[]}
+                pillar={0}
+                consentState={{}}
+                overrideImage={overlayImage}
+                shouldStick={false}
+                isMainMedia={false}
+            />
+        );
+        const { getByTestId } = render(atom);
+        const overlay = getByTestId('youtube-overlay-ZCvZmYlQD8');
+        const ariaLabel = overlay.getAttribute('aria-label');
+
+        expect(ariaLabel).toBe(`Play video: ${title}`);
+    });
+
     it('shows a placeholder if overlay is missing', async () => {
         const atom = (
             <YoutubeAtom
@@ -72,7 +116,7 @@ describe('YoutubeAtom', () => {
                 eventEmitters={[]}
                 pillar={0}
                 shouldStick={false}
-                mainMedia={false}
+                isMainMedia={false}
             />
         );
         const { getByTestId } = render(atom);
@@ -91,7 +135,7 @@ describe('YoutubeAtom', () => {
                 pillar={0}
                 overrideImage={overlayImage}
                 shouldStick={false}
-                mainMedia={false}
+                isMainMedia={false}
             />
         );
         const { getByTestId } = render(atom);
@@ -110,7 +154,7 @@ describe('YoutubeAtom', () => {
                 pillar={0}
                 overrideImage={overlayImage}
                 shouldStick={false}
-                mainMedia={false}
+                isMainMedia={false}
             />
         );
         const { getByTestId } = render(atom);
@@ -133,7 +177,7 @@ describe('YoutubeAtom', () => {
                     pillar={0}
                     overrideImage={overlayImage}
                     shouldStick={false}
-                    mainMedia={false}
+                    isMainMedia={false}
                 />
                 <YoutubeAtom
                     title="My Youtube video 2!"
@@ -144,7 +188,7 @@ describe('YoutubeAtom', () => {
                     pillar={0}
                     overrideImage={overlayImage}
                     shouldStick={false}
-                    mainMedia={false}
+                    isMainMedia={false}
                 />
             </>
         );

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -160,6 +160,7 @@ export const YoutubeAtom = ({
                         role={role}
                         duration={duration}
                         pillar={pillar}
+                        title={title}
                         onClick={() => setOverlayClicked(true)}
                     />
                 )}

--- a/src/YoutubeAtomOverlay.tsx
+++ b/src/YoutubeAtomOverlay.tsx
@@ -121,6 +121,7 @@ export const YoutubeAtomOverlay = ({
                 }
             }}
             css={overlayStyles}
+            tabIndex={0}
             aria-label={`Play video: ${title}`}
         >
             <Picture

--- a/src/YoutubeAtomOverlay.tsx
+++ b/src/YoutubeAtomOverlay.tsx
@@ -25,6 +25,7 @@ type Props = {
     role: RoleType;
     duration?: number; // in seconds
     pillar: ArticleTheme;
+    title?: string;
     onClick: () => void;
 };
 
@@ -104,6 +105,7 @@ export const YoutubeAtomOverlay = ({
     role,
     duration,
     pillar,
+    title,
     onClick,
 }: Props): JSX.Element => {
     return (
@@ -119,7 +121,7 @@ export const YoutubeAtomOverlay = ({
                 }
             }}
             css={overlayStyles}
-            tabIndex={0}
+            aria-label={`Play video: ${title}`}
         >
             <Picture
                 imageSources={overrideImage || posterImage || []}

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -246,6 +246,7 @@ export const YoutubeAtomPlayer = ({
                         relatedChannels: [],
                         adsConfig,
                     },
+                    title,
                 });
 
                 /**


### PR DESCRIPTION
## What does this change?

This PR addresses issues raised in the DAC report by adding an `aria-label` to the `YoutubeAtom` overlay `play` button, and a `title` to the iframe.

DAC Issues:
[Ensure all <frame> and <iframe> elements have valid title attribute values.
](https://drive.google.com/file/d/1ZXsQqmImEIx0cirPPRsaX1LKRCeoPZp5/view)

[For each instance of this ‘Play Video’ button, the video that it is in relation should be included within
the button text.](https://drive.google.com/file/d/1hBH7i4qJVeh6Wu_laQ5FLzmL_IZbAjIe/view)
