### PR TITLE
stop other playing videos when a video plays

### DIFF
--- a/.changeset/pink-drinks-give.md
+++ b/.changeset/pink-drinks-give.md
@@ -1,0 +1,5 @@
+---
+'@guardian/atoms-rendering': patch
+---
+
+Handle multiple videos

--- a/src/YoutubeAtom.stories.tsx
+++ b/src/YoutubeAtom.stories.tsx
@@ -311,3 +311,42 @@ export const StickyMainMedia = (): JSX.Element => {
         </div>
     );
 };
+
+export const multipleVideo = (): JSX.Element => {
+    return (
+        <div style={{ width: '500px' }}>
+            <YoutubeAtom
+                assetId="-ZCvZmYlQD8"
+                alt=""
+                role="inline"
+                eventEmitters={[
+                    (e) => console.log(`analytics event ${e} called`),
+                ]}
+                consentState={{}}
+                duration={252}
+                pillar={ArticlePillar.Culture}
+                height={450}
+                width={800}
+                shouldStick={true}
+                isMainMedia={true}
+                title="Rayshard Brooks: US justice system treats us like 'animals'"
+            />
+            <YoutubeAtom
+                assetId="3jpXAMwRSu4"
+                alt=""
+                role="inline"
+                eventEmitters={[
+                    (e) => console.log(`analytics event ${e} called`),
+                ]}
+                consentState={{}}
+                duration={252}
+                pillar={ArticlePillar.Culture}
+                height={450}
+                width={800}
+                shouldStick={true}
+                isMainMedia={true}
+                title="Rayshard Brooks: US justice system treats us like 'animals'"
+            />
+        </div>
+    );
+};

--- a/src/YoutubeAtom.stories.tsx
+++ b/src/YoutubeAtom.stories.tsx
@@ -312,7 +312,7 @@ export const StickyMainMedia = (): JSX.Element => {
     );
 };
 
-export const multipleVideo = (): JSX.Element => {
+export const MultipleVideos = (): JSX.Element => {
     return (
         <div style={{ width: '500px' }}>
             <YoutubeAtom

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -299,7 +299,7 @@ export const YoutubeAtomPlayer = ({
                             const playerStatePromise = player.current?.getPlayerState();
                             playerStatePromise?.then((state) => {
                                 if (state === YT.PlayerState.PLAYING) {
-                                    player.current?.stopVideo();
+                                    player.current?.pauseVideo();
                                 }
                             });
                         }

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -365,7 +365,7 @@ export const YoutubeAtomPlayer = ({
                 );
 
                 /**
-                 * Record the playerListeners so they can be unregistered on component unmount
+                 * Record the listeners using refs so they can be separately unregistered _only_ on component unmount
                  */
                 playerReadyListener &&
                     playerListeners.current.push(playerReadyListener);

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -32,7 +32,7 @@ declare global {
 
 type YoutubeCallback = (e: YT.PlayerEvent & YT.OnStateChangeEvent) => void;
 
-type PlayCustomEventDetail = { videoId: string };
+type CustomPlayEventDetail = { videoId: string };
 const customPlayEventName = 'video:play';
 
 /**
@@ -357,7 +357,7 @@ export const YoutubeAtomPlayer = ({
      * Pause the current video when another video is played on the same page
      */
     const handlePauseVideo = (
-        event: CustomEventInit<PlayCustomEventDetail>,
+        event: CustomEventInit<CustomPlayEventDetail>,
     ) => {
         if (event instanceof CustomEvent) {
             if (event.detail.videoId !== videoId) {

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -75,27 +75,31 @@ const createOnStateChangeListener = (
      */
     const player = event.target;
 
-    if (event.data === YT.PlayerState.PLAYING) {
-        const iframes = document.getElementsByTagName('iframe');
-        const atomsArray = Array.from(iframes);
+    /**
+     * the ID of the iframe
+     */
+    const atomId = `youtube-video-${videoId}`;
 
-        atomsArray.forEach((iframe) => {
-            const src = iframe.getAttribute('src');
-            if (
-                iframe &&
-                iframe.id !== `youtube-video-${videoId}` &&
-                src &&
-                src.indexOf('youtube.com/embed') !== -1
-            ) {
-                console.log(iframe.id);
-                iframe.contentWindow?.postMessage(
-                    JSON.stringify({
-                        event: 'command',
-                        func: 'stopVideo',
-                        args: [],
-                    }),
-                    '*',
-                );
+    if (event.data === YT.PlayerState.PLAYING) {
+        const youtubeIframes = document.querySelectorAll(
+            '[data-atom-type="youtube"]',
+        );
+
+        /**
+         * send a 'stopVideo' postMessage to all other YoutubeAtoms
+         */
+        Array.from(youtubeIframes).forEach((iframe) => {
+            if (iframe instanceof HTMLIFrameElement) {
+                if (iframe?.id !== atomId) {
+                    iframe.contentWindow?.postMessage(
+                        JSON.stringify({
+                            event: 'command',
+                            func: 'stopVideo',
+                            args: [],
+                        }),
+                        'https://www.youtube.com/',
+                    );
+                }
             }
         });
 

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -235,6 +235,10 @@ export const YoutubeAtomPlayer = ({
         hasSentEndEvent: false,
     });
     const playerListeners = useRef<Array<YoutubeCallback>>([]);
+
+    /**
+     * A map ref with a key of eventname and a value of eventHandler
+     */
     const customListeners = useRef<
         Record<string, (event: CustomEventInit<CustomPlayEventDetail>) => void>
     >({});

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -75,11 +75,6 @@ const createOnStateChangeListener = (
      */
     const player = event.target;
 
-    /**
-     * the ID of the iframe
-     */
-    const atomId = `youtube-video-${videoId}`;
-
     if (event.data === YT.PlayerState.PLAYING) {
         const youtubeIframes = document.querySelectorAll(
             '[data-atom-type="youtube"]',
@@ -90,7 +85,8 @@ const createOnStateChangeListener = (
          */
         Array.from(youtubeIframes).forEach((iframe) => {
             if (iframe instanceof HTMLIFrameElement) {
-                if (iframe?.id !== atomId) {
+                // filtering out the current component playing video
+                if (iframe.id !== `youtube-video-${videoId}`) {
                     iframe.contentWindow?.postMessage(
                         JSON.stringify({
                             event: 'command',

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -62,7 +62,9 @@ const createOnStateChangeListener = (
     videoId: string,
     progressEvents: ProgressEvents,
     eventEmitters: Props['eventEmitters'],
+    atomIds: string[],
 ): YT.PlayerEventHandler<YT.OnStateChangeEvent> => (event) => {
+    console.log(atomIds);
     const loggerFrom = 'YoutubeAtomPlayer onStateChange';
     log('dotcom', {
         from: loggerFrom,
@@ -76,6 +78,15 @@ const createOnStateChangeListener = (
     const player = event.target;
 
     if (event.data === YT.PlayerState.PLAYING) {
+        const otherPlayer: YoutubePlayerType = YouTubePlayer(
+            `youtube-video-${atomIds[0]}`,
+            {
+                videoId: atomIds[0],
+            },
+        );
+
+        otherPlayer.stopVideo();
+
         if (!progressEvents.hasSentPlayEvent) {
             log('dotcom', {
                 from: loggerFrom,
@@ -201,6 +212,8 @@ export const YoutubeAtomPlayer = ({
         hasSentEndEvent: false,
     });
     const listeners = useRef<Array<YoutubeCallback>>([]);
+    //const otherPlayer = useRef<YoutubePlayerType | undefined>();
+    const otherAtomIds = useRef<string[]>([]);
 
     /**
      * Initialise player useEffect
@@ -252,6 +265,7 @@ export const YoutubeAtomPlayer = ({
                     videoId,
                     progressEvents.current,
                     eventEmitters,
+                    otherAtomIds.current,
                 );
 
                 const playerStateChangeListener = player.current?.on(
@@ -353,6 +367,19 @@ export const YoutubeAtomPlayer = ({
         };
     }, []);
 
+    useEffect(() => {
+        const otherAtoms = document.querySelectorAll(
+            '[data-atom-type="youtube"]',
+        );
+        const atomsArray = Array.from(otherAtoms);
+        console.log(atomsArray);
+        atomsArray.forEach((atom) => {
+            if (atom.id !== `youtube-video-${videoId}`) {
+                console.log(`atom id ${atom.id} is pushed`);
+                otherAtomIds.current?.push(atom.id);
+            }
+        });
+    }, []);
     /**
      * An element for the YouTube iFrame to hook into the dom
      */

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -358,7 +358,7 @@ export const YoutubeAtomPlayer = ({
      */
     const handlePauseVideo = (
         event: CustomEventInit<PlayCustomEventDetail>,
-    ): void => {
+    ) => {
         if (event instanceof CustomEvent) {
             if (event.detail.videoId !== videoId) {
                 const playerStatePromise = player.current?.getPlayerState();

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -62,9 +62,7 @@ const createOnStateChangeListener = (
     videoId: string,
     progressEvents: ProgressEvents,
     eventEmitters: Props['eventEmitters'],
-    atomIds: string[],
 ): YT.PlayerEventHandler<YT.OnStateChangeEvent> => (event) => {
-    console.log(atomIds);
     const loggerFrom = 'YoutubeAtomPlayer onStateChange';
     log('dotcom', {
         from: loggerFrom,
@@ -78,14 +76,28 @@ const createOnStateChangeListener = (
     const player = event.target;
 
     if (event.data === YT.PlayerState.PLAYING) {
-        const otherPlayer: YoutubePlayerType = YouTubePlayer(
-            `youtube-video-${atomIds[0]}`,
-            {
-                videoId: atomIds[0],
-            },
-        );
+        const iframes = document.getElementsByTagName('iframe');
+        const atomsArray = Array.from(iframes);
 
-        otherPlayer.stopVideo();
+        atomsArray.forEach((iframe) => {
+            const src = iframe.getAttribute('src');
+            if (
+                iframe &&
+                iframe.id !== `youtube-video-${videoId}` &&
+                src &&
+                src.indexOf('youtube.com/embed') !== -1
+            ) {
+                console.log(iframe.id);
+                iframe.contentWindow?.postMessage(
+                    JSON.stringify({
+                        event: 'command',
+                        func: 'stopVideo',
+                        args: [],
+                    }),
+                    '*',
+                );
+            }
+        });
 
         if (!progressEvents.hasSentPlayEvent) {
             log('dotcom', {
@@ -212,8 +224,6 @@ export const YoutubeAtomPlayer = ({
         hasSentEndEvent: false,
     });
     const listeners = useRef<Array<YoutubeCallback>>([]);
-    //const otherPlayer = useRef<YoutubePlayerType | undefined>();
-    const otherAtomIds = useRef<string[]>([]);
 
     /**
      * Initialise player useEffect
@@ -265,7 +275,6 @@ export const YoutubeAtomPlayer = ({
                     videoId,
                     progressEvents.current,
                     eventEmitters,
-                    otherAtomIds.current,
                 );
 
                 const playerStateChangeListener = player.current?.on(
@@ -367,19 +376,6 @@ export const YoutubeAtomPlayer = ({
         };
     }, []);
 
-    useEffect(() => {
-        const otherAtoms = document.querySelectorAll(
-            '[data-atom-type="youtube"]',
-        );
-        const atomsArray = Array.from(otherAtoms);
-        console.log(atomsArray);
-        atomsArray.forEach((atom) => {
-            if (atom.id !== `youtube-video-${videoId}`) {
-                console.log(`atom id ${atom.id} is pushed`);
-                otherAtomIds.current?.push(atom.id);
-            }
-        });
-    }, []);
     /**
      * An element for the YouTube iFrame to hook into the dom
      */


### PR DESCRIPTION
Paired with @joecowton1 and @arelra 

## What does this change?
This PR adds logic to pause the video whenever another video is played in the same page. This way we can't have multiple videos playing simultaneously. 
 
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
**Storybook:**  this feature has been tested in storybook and can be checked [here](https://5f22d2148807980022fc782e-aryeqruwej.chromatic.com/?path=/story/youtubeatom--multiple-videos)

**Manual testing in DCR CODE after publishing the package:** This change needs to be deployed and published. We can then test DCR in code using the new version of atoms-rendering by going to this [page](http://localhost:3030/Article?url=https://www.theguardian.com/world/live/2022/mar/28/russia-ukraine-war-latest-news-zelenskiy-putin-live-updates) which has three videos. 
when 1 video is already playing, if you play the other video, it should stop the previous video. 

**Cypres test in DCR:** This functionality is expected to have Cypress testing in DCR
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
If the test in DCR code works as we expect.
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images


https://user-images.githubusercontent.com/15894063/161256708-d7620ea1-7d15-457a-af80-625be820df49.mov



<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [ ] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)
- [ ] [Colour contrast passed](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#use-of-colour)
