### PR TITLE
Fix: sticky video content layout jump 

### DIFF
--- a/.changeset/late-birds-deliver.md
+++ b/.changeset/late-birds-deliver.md
@@ -1,0 +1,5 @@
+---
+'@guardian/atoms-rendering': patch
+---
+
+fix: content jump on sticky video close

--- a/src/YoutubeAtomSticky.tsx
+++ b/src/YoutubeAtomSticky.tsx
@@ -80,17 +80,18 @@ const stickyStyles = css`
 `;
 
 const stickyContainerStyles = (isMainMedia?: boolean) => {
-    const height = 192;
+    const videoHeight = 192;
+    const largeVideoHeight = 349;
 
     return css`
-        height: ${height}px;
+        height: ${videoHeight}px;
         position: relative;
         display: flex;
         justify-content: flex-end;
         padding-right: ${isMainMedia ? `${space[5]}px` : 0};
 
-        ${from.tablet} {
-            height: ${height * 2}px;
+        ${from.phablet} {
+            height: ${largeVideoHeight}px;
         }
     `;
 };

--- a/src/YoutubeAtomSticky.tsx
+++ b/src/YoutubeAtomSticky.tsx
@@ -80,18 +80,15 @@ const stickyStyles = css`
 `;
 
 const stickyContainerStyles = (isMainMedia?: boolean) => {
-    const videoHeight = 192;
-    const largeVideoHeight = 349;
-
     return css`
-        height: ${videoHeight}px;
+        height: 192px;
         position: relative;
         display: flex;
         justify-content: flex-end;
         padding-right: ${isMainMedia ? `${space[5]}px` : 0};
 
         ${from.phablet} {
-            height: ${largeVideoHeight}px;
+            height: 349px;
         }
     `;
 };


### PR DESCRIPTION
## What does this change?
Reduces the height of the sticky video container to match the video height for phablets and above to prevent a content shift when the video sticks, is closed or is reinserted into its container.

## Before
https://user-images.githubusercontent.com/20416599/161040586-e31d6a52-bdc4-4552-9dbc-e620e1c44dc5.mov

## After
https://user-images.githubusercontent.com/20416599/161040495-4cd9d52a-cf3b-4061-9380-551b894d97ed.mov


