### PR TITLE
YoutubeAtomPlayer `useOnMount` custom hook

### DIFF
--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -354,9 +354,13 @@ export const YoutubeAtomPlayer = ({
         const playerReadyListener = player.current?.on('ready', readyListener);
 
         /**
-         * Return the cleanup effect that will run _only_ on unmount via useOnMount API
+         * Return the cleanup function that will run _only_ on unmount via useOnMount API
          */
         return () => {
+            log('dotcom', {
+                from: 'YoutubeAtomPlayer cleanup',
+                videoId,
+            });
             playerReadyListener && player.current?.off(playerReadyListener);
             playerStateChangeListener &&
                 player.current?.off(playerStateChangeListener);

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -402,30 +402,6 @@ export const YoutubeAtomPlayer = ({
     }, [stopVideo]);
 
     /**
-     * Unregister listeners useEffect
-     */
-    useEffect(() => {
-        /**
-         * Unregister listeners on component unmount
-         *
-         * A useEffect with an empty dependency array will
-         * call its cleanup on unmount and not after every
-         * useEffect update.
-         */
-        return () => {
-            playerListeners.current.forEach((playerListener) => {
-                player.current?.off(playerListener);
-            });
-
-            Object.entries(customListeners.current).forEach(
-                ([eventName, eventHandler]) => {
-                    document.removeEventListener(eventName, eventHandler);
-                },
-            );
-        };
-    }, []);
-
-    /**
      * An element for the YouTube iFrame to hook into the dom
      */
     return (

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -238,18 +238,10 @@ export const YoutubeAtomPlayer = ({
         hasSent75Event: false,
         hasSentEndEvent: false,
     });
-    const playerListeners = useRef<Array<YoutubeCallback>>([]);
-
-    /**
-     * A map ref with a key of eventname and a value of eventHandler
-     */
-    const customListeners = useRef<
-        Record<string, (event: CustomEventInit<CustomPlayEventDetail>) => void>
-    >({});
     const id = `youtube-video-${uniqueId}`;
 
     /**
-     * Initialise player useEffect
+     * Initialise player
      */
     useOnMount(() => {
         log('dotcom', {
@@ -362,28 +354,14 @@ export const YoutubeAtomPlayer = ({
         const playerReadyListener = player.current?.on('ready', readyListener);
 
         /**
-         * Record the listeners using refs so they can be separately unregistered _only_ on component unmount
-         */
-        playerReadyListener &&
-            playerListeners.current.push(playerReadyListener);
-        playerStateChangeListener &&
-            playerListeners.current.push(playerStateChangeListener);
-
-        customListeners.current[customPlayEventName] = handlePauseVideo;
-
-        /**
-         * Return the cleanup effect that will run _only_ on component unmount via useOnMount
+         * Return the cleanup effect that will run _only_ on unmount via useOnMount API
          */
         return () => {
-            playerListeners.current.forEach((playerListener) => {
-                player.current?.off(playerListener);
-            });
+            playerReadyListener && player.current?.off(playerReadyListener);
+            playerStateChangeListener &&
+                player.current?.off(playerStateChangeListener);
 
-            Object.entries(customListeners.current).forEach(
-                ([eventName, eventHandler]) => {
-                    document.removeEventListener(eventName, eventHandler);
-                },
-            );
+            document.removeEventListener(customPlayEventName, handlePauseVideo);
         };
     });
 

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -243,7 +243,20 @@ export const YoutubeAtomPlayer = ({
     /**
      * Initialise player
      *
-     * Please refer to the JS Doc for useOnMount to understand it's API
+     * Please refer to the useOnMount API
+     *
+     * The following dependencies are used with the values set at component mount:
+     *
+     * adTargeting,
+     * autoPlay,
+     * consentState, *this must be defined*
+     * eventEmitters,
+     * height,
+     * onReady,
+     * origin,
+     * videoId,
+     * width,
+     *
      */
     useOnMount(() => {
         log('dotcom', {

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -242,6 +242,8 @@ export const YoutubeAtomPlayer = ({
 
     /**
      * Initialise player
+     *
+     * Please refer to the JS Doc for useOnMount to understand it's API
      */
     useOnMount(() => {
         log('dotcom', {

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -373,7 +373,7 @@ export const YoutubeAtomPlayer = ({
          */
         return () => {
             log('dotcom', {
-                from: 'YoutubeAtomPlayer cleanup',
+                from: 'YoutubeAtomPlayer cleanup and unmount',
                 videoId,
             });
             playerReadyListener && player.current?.off(playerReadyListener);

--- a/src/lib/useOnMount.ts
+++ b/src/lib/useOnMount.ts
@@ -1,0 +1,10 @@
+import { useEffect } from 'react';
+
+/**
+ * Ensures:
+ * - `task` is only run on mount
+ * - the cleanup function returned by the `task` is only run on unmount
+ * @param {Function} task - The task to execute once
+ * */
+export const useOnMount = (task: () => () => void): void =>
+    useEffect(() => task(), []);

--- a/src/lib/useOnMount.ts
+++ b/src/lib/useOnMount.ts
@@ -3,7 +3,12 @@ import { useEffect } from 'react';
 /**
  * Ensures:
  * - `task` is only run on mount
- * - the cleanup function returned by the `task` is only run on unmount
+ * - the cleanup function returned by `task` is only run on unmount
+ *
+ * Any props or state used by `task` will have the values at the time of component mount.
+ * Any re-renders with changed values will not cause task to rerun.
+ *
+ * Be careful that this is what you want!
  * @param {Function} task - The task to execute once
  * */
 export const useOnMount = (task: () => () => void): void =>


### PR DESCRIPTION
## What does this change?

Introduces a new custom hook `useOnMount`.

Positives:

- declarative `onMount`
- abstracts away thinking about re-renders, useEffect triggers, mount and unmounting
- enforces the effect to only run on mount i.e. we could use useEffect with `[]` but it's open to misuse and re-triggering
- allows a cleanup function to be returned in a more idiomatic 'unmount' way
- allows the listener refs to be removed and the separate unmount useEffect

Negatives:

- abstracts away thinking about re-renders, triggers, mount and unmounting :) . I think we've learnt a great deal by having to deal with these concepts. Perhaps we are shielding future developers from that learning curve? Is this a negative?
- dependencies are less explicit by the fact that they are captured by the mount function and no longer declared

@marjisound and @joecowton1 I am not sure whether this is a useful abstraction so I'd be interested in your feedback !


