### PR TITLE
Remove pause and resume events from `YoutubeAtom` playerState function

### DIFF
--- a/.changeset/orange-nails-care.md
+++ b/.changeset/orange-nails-care.md
@@ -1,0 +1,5 @@
+---
+'@guardian/atoms-rendering': patch
+---
+
+Remove pause and resume events from playerState

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -67,11 +67,9 @@ export const YoutubeAtom = ({
     const playerState = (videoEvent: VideoEventKey) => {
         switch (videoEvent) {
             case 'play':
-            case 'resume':
                 setStopVideo(false);
                 setIsPlaying(true);
                 break;
-            case 'pause':
             case 'end':
             case 'cued':
                 setIsPlaying(false);

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -46,7 +46,6 @@ type YoutubePlayerType = {
     loadVideoById: (videoId: string) => void;
     playVideo: () => void;
     stopVideo: () => void;
-    pauseVideo: () => void;
     getCurrentTime: () => number;
     getDuration: () => number;
     getPlayerState: () => Promise<YT.PlayerState>;
@@ -306,9 +305,9 @@ export const YoutubeAtomPlayer = ({
                 );
 
                 /**
-                 * Pause the current video when another video is played on the same page
+                 * Stop the current video when another video is played on the same page
                  */
-                const handlePauseVideo = (
+                const handleStopVideo = (
                     event: CustomEventInit<CustomPlayEventDetail>,
                 ) => {
                     if (event instanceof CustomEvent) {
@@ -317,7 +316,7 @@ export const YoutubeAtomPlayer = ({
                                 player.current?.getPlayerState();
                             playerStatePromise?.then((state) => {
                                 if (state === YT.PlayerState.PLAYING) {
-                                    player.current?.pauseVideo();
+                                    player.current?.stopVideo();
                                 }
                             });
                         }
@@ -327,10 +326,7 @@ export const YoutubeAtomPlayer = ({
                 /**
                  * add listener for custom play event
                  */
-                document.addEventListener(
-                    customPlayEventName,
-                    handlePauseVideo,
-                );
+                document.addEventListener(customPlayEventName, handleStopVideo);
 
                 /**
                  * Register an onReady listener
@@ -377,7 +373,7 @@ export const YoutubeAtomPlayer = ({
                 playerStateChangeListener &&
                     playerListeners.current.push(playerStateChangeListener);
 
-                customListeners.current[customPlayEventName] = handlePauseVideo;
+                customListeners.current[customPlayEventName] = handleStopVideo;
             }
         },
         /**


### PR DESCRIPTION
## What does this change?

@paperboyo reported an issue where clicking along a sticky video's timeline would cause the video to stick and unstick. 

This was caused by the `play` and `resume` video events sticking and unsticking the video via the `isPlaying` state in the `YoutubeAtom`.

To resolve this issue we've removed those events from the `playerState` function, and reverted to using `stop` rather than `pause` when multiple videos are played on the same page. If we'd left this so the previous video was paused when a new video was played, they both would remain sticky rather returning to the original container.

### Before

https://user-images.githubusercontent.com/77005274/162753873-cf92bc80-f61e-40f4-8421-a51d783f84df.mov

### After

https://user-images.githubusercontent.com/77005274/162753962-65bec82f-7a08-4772-af7d-c87bd351a96e.mov


