### PR TITLE
Add missing 'tablet' flag to isMobile config in `YoutubeAtomSticky` 

### DIFF
--- a/.changeset/loud-eels-notice.md
+++ b/.changeset/loud-eels-notice.md
@@ -1,0 +1,5 @@
+---
+'@guardian/atoms-rendering': patch
+---
+
+Add missing tablet flag to isMobile check in YoutubeAtomSticky

--- a/src/YoutubeAtomSticky.tsx
+++ b/src/YoutubeAtomSticky.tsx
@@ -117,7 +117,7 @@ type Props = {
     children: JSX.Element;
 };
 
-const isMobile = detectMobile();
+const isMobile = detectMobile({ tablet: true });
 
 export const YoutubeAtomSticky = ({
     videoId,


### PR DESCRIPTION
## What does this change?

Adds a missing flag to include tablets in the device check: https://github.com/juliangruber/is-mobile
