### PR TITLE
Move isMobile dependency

### DIFF
--- a/.changeset/beige-snails-agree.md
+++ b/.changeset/beige-snails-agree.md
@@ -1,0 +1,5 @@
+---
+'@guardian/atoms-rendering': patch
+---
+
+Move isMobile dependency

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.29.4",
         "husky": "^4.3.0",
-        "is-mobile": "^3.1.1",
         "jest": "^26.6.3",
         "jest-environment-jsdom-sixteen": "^1.0.3",
         "lodash.debounce": "^4.0.6",
@@ -147,6 +146,7 @@
         ]
     },
     "dependencies": {
+        "is-mobile": "^3.1.1",
         "youtube-player": "^5.5.2"
     }
 }


### PR DESCRIPTION
## What does this change?

Moves `isMobile` dependency to `dependencies` as the DCR check's were failing with it as a dev dependency.
