### PR TITLE
Recipe schema atom

### DIFF
--- a/.changeset/wise-badgers-impress.md
+++ b/.changeset/wise-badgers-impress.md
@@ -1,0 +1,5 @@
+---
+'@guardian/atoms-rendering': minor
+---
+
+Adds a barebones recipe schema atom

--- a/src/RecipeSchemaAtom.test.tsx
+++ b/src/RecipeSchemaAtom.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import { render } from '@testing-library/react';
+
+import { RecipeSchemaAtom } from './RecipeSchemaAtom';
+
+describe('RecipeSchemaAtom', () => {
+    it('should render', () => {
+        const { getByTestId } = render(
+            <RecipeSchemaAtom
+                id="abc456"
+                json={`
+            {
+                "@context":"https://schema.org/",
+                "@type":"Recipe",
+                "name":"The perfect hamburger",
+                "image":[
+                   "https://i.guim.co.uk/img/static/sys-images/Guardian/Pix/pictures/2010/8/3/1280851276363/Perfect-hamburger-006.jpg?width=700&quality=45&auto=format&fit=max&dpr=2&s=32ffe62eaad00a538d50aedc097237d7"
+                ],
+                "author":{
+                   "@type":"Person",
+                   "name":"Felicity Cloake"
+                },
+                "datePublished":"2010-08-05",
+                "description":"Burgers may be fast food, but they're also a craft.",
+                "prepTime":"PT80M",
+                "cookTime":"PT100M",
+                "totalTime":"PT180M",
+                "keywords":"burgers, barbecue",
+                "recipeYield":"6",
+                "recipeCategory":"Main",
+                "recipeCuisine":"American",
+                "nutrition":{
+                   "@type":"NutritionInformation",
+                   "calories":"1000 calories"
+                },
+                "recipeIngredient":[
+                   "1 tbsp oil or butter",
+                   "1 large onion, finely chopped",
+                   "1kg roughly minced chuck steak (or any non-lean mince)",
+                   "100ml stout",
+                   "2 tbsp brown breadcrumbs",
+                   "2 tsp chopped herbs (parsley or thyme work well)",
+                   "1 tsp salt",
+                   "Black pepper",
+                   "Garnishes, sauces and rolls, as desired"
+                ],
+                "recipeInstructions":[
+                   {
+                      "@type":"HowToStep",
+                      "name":"Brown the onion",
+                      "text":"Heat the oil in a frying pan over a low heat, and cook the onion until soft and slightly browned. Leave to cool."
+                   },
+                   {
+                      "@type":"HowToStep",
+                      "name":"Prepare the meat for cooking",
+                      "text":"Spread the beef out and sprinkle over the onion. Add the stout, breadcrumbs, herbs and seasoning and mix together with a fork, being careful not to overwork it."
+                   },
+                   {
+                      "@type":"HowToStep",
+                      "name":"Divide into burgers",
+                      "text":"Divide the meat into 12 flattish burgers, putting a dimple in the centre of each. Cover and refrigerate for an hour."
+                   },
+                   {
+                      "@type":"HowToStep",
+                      "name":"Cook the burgers!",
+                      "text":"Cook the burgers on a medium to hot barbecue or griddle pan: leave them undisturbed for the first 3 minutes so they build up a good seal on the bottom, then carefully turn them over, adding a slice of cheese on top if desired. Cook for a further 4 minutes for rare, and 7 for well done, and allow to rest for a few minutes before serving. (You can toast buns, cut-side down, on the barbecue at this point.)"
+                   }
+                ]
+             }
+            `}
+            />,
+        );
+
+        expect(getByTestId('recipe')).toBeInTheDocument();
+    });
+});

--- a/src/RecipeSchemaAtom.tsx
+++ b/src/RecipeSchemaAtom.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import { RecipeSchemaAtomType } from './types';
+
+export const RecipeSchemaAtom = ({
+    id,
+    json,
+}: RecipeSchemaAtomType): JSX.Element => {
+    return (
+        <div data-atom-id={id} data-atom-type="recipe" data-testid="recipe">
+            <script type="application/ld+json">{json}</script>
+        </div>
+    );
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { PersonalityQuizAtom } from './PersonalityQuiz';
 import { KnowledgeQuizAtom } from './KnowledgeQuiz';
 import { TimelineAtom } from './TimelineAtom';
 import { VideoAtom } from './VideoAtom';
+import { RecipeSchemaAtom } from './RecipeSchemaAtom';
 
 export {
     ExplainerAtom,
@@ -26,4 +27,5 @@ export {
     KnowledgeQuizAtom,
     TimelineAtom,
     VideoAtom,
+    RecipeSchemaAtom as RecipeAtom,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -167,3 +167,8 @@ export type VideoEventKey =
     | 'cued'
     | 'resume'
     | 'pause';
+
+export type RecipeSchemaAtomType = {
+    id: string;
+    json: string;
+};


### PR DESCRIPTION
This is an attempt to add a barebones recipe atom which simply renders [schema](https://schema.org/Recipe) out of sight for the benefit of web crawlers/search engines. This is part of a proposed experiment to get structured data on a handful of recipe pages and get a before/after view on search engine performance.

We believe all that's needed is a script tag containing a [JSON-LD](https://json-ld.org/) blob. The example used in the atom test has been run through Google's [Rich Results Test](https://search.google.com/test/rich-results) and seems to work fine. 

My thanks to @shtukas for helping me piece this together!