### PR TITLE
fix: Add aria labels to like dislike buttons

### DIFF
--- a/.changeset/new-panthers-retire.md
+++ b/.changeset/new-panthers-retire.md
@@ -1,0 +1,5 @@
+---
+'@guardian/atoms-rendering': patch
+---
+
+Adding improved labels to like & dislike button for Q&A atom

--- a/src/expandableAtom/Footer.tsx
+++ b/src/expandableAtom/Footer.tsx
@@ -75,7 +75,7 @@ export const Footer = ({
                 >
                     <div>Was this helpful?</div>
                     <button
-                        aria-label="Like"
+                        aria-label="yes"
                         data-testid="like"
                         css={buttonStyling}
                         onClick={() => {
@@ -86,7 +86,7 @@ export const Footer = ({
                         <ThumbImage />
                     </button>
                     <button
-                        aria-label="Dislike"
+                        aria-label="no"
                         css={[
                             buttonStyling,
                             css`

--- a/src/expandableAtom/Footer.tsx
+++ b/src/expandableAtom/Footer.tsx
@@ -75,6 +75,7 @@ export const Footer = ({
                 >
                     <div>Was this helpful?</div>
                     <button
+                        aria-label="Like"
                         data-testid="like"
                         css={buttonStyling}
                         onClick={() => {
@@ -85,6 +86,7 @@ export const Footer = ({
                         <ThumbImage />
                     </button>
                     <button
+                        aria-label="Dislike"
                         css={[
                             buttonStyling,
                             css`

--- a/src/expandableAtom/Footer.tsx
+++ b/src/expandableAtom/Footer.tsx
@@ -75,7 +75,7 @@ export const Footer = ({
                 >
                     <div>Was this helpful?</div>
                     <button
-                        aria-label="yes"
+                        aria-label="yes, this was helpful"
                         data-testid="like"
                         css={buttonStyling}
                         onClick={() => {
@@ -86,7 +86,7 @@ export const Footer = ({
                         <ThumbImage />
                     </button>
                     <button
-                        aria-label="no"
+                        aria-label="no, this was not helpful"
                         css={[
                             buttonStyling,
                             css`


### PR DESCRIPTION
## What does this change?

Adds `aria-label` to like and dislike buttons, previously a screen reader would announce these as "button" instead of anything descriptive.

Also makes them easier to click from voice control.

Fixes guardian/dotcom-rendering#5073

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [x] [Tested with screen reader](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#screen-readers)
- [X] [Navigable with keyboard](https://guardian.github.io/source/?path=/docs/docs-06-accessibility--page#keyboard-navigation)