### PR TITLE
Ash/youtube atom zero

### DIFF
--- a/.changeset/great-zoos-double.md
+++ b/.changeset/great-zoos-double.md
@@ -1,0 +1,5 @@
+---
+'@guardian/atoms-rendering': patch
+---
+
+Don't display a 0 if we're unable to get the duration of a youtube video.

--- a/src/YoutubeAtomOverlay.tsx
+++ b/src/YoutubeAtomOverlay.tsx
@@ -135,7 +135,7 @@ export const YoutubeAtomOverlay = ({
                 >
                     <SvgPlay />
                 </div>
-                {duration > 0 && (
+                {duration !== undefined && duration > 0 && (
                     <div css={videoDurationStyles(pillar)}>
                         {formatTime(duration)}
                     </div>

--- a/src/YoutubeAtomOverlay.tsx
+++ b/src/YoutubeAtomOverlay.tsx
@@ -135,7 +135,7 @@ export const YoutubeAtomOverlay = ({
                 >
                     <SvgPlay />
                 </div>
-                {duration && (
+                {duration !== undefined && (
                     <div css={videoDurationStyles(pillar)}>
                         {formatTime(duration)}
                     </div>

--- a/src/YoutubeAtomOverlay.tsx
+++ b/src/YoutubeAtomOverlay.tsx
@@ -135,7 +135,7 @@ export const YoutubeAtomOverlay = ({
                 >
                     <SvgPlay />
                 </div>
-                {duration !== undefined && (
+                {duration > 0 && (
                     <div css={videoDurationStyles(pillar)}>
                         {formatTime(duration)}
                     </div>


### PR DESCRIPTION
## What does this change?

Only render the duration overlay on Youtube atoms if duration is not undefined. Sometimes we're unable to get the length of a youtube video and the duration defaults to "0"