### PR TITLE
Remove `youtube-player` library

### DIFF
--- a/.changeset/seven-meals-think.md
+++ b/.changeset/seven-meals-think.md
@@ -1,0 +1,5 @@
+---
+'@guardian/atoms-rendering': minor
+---
+
+Remove youtube-player library

--- a/package.json
+++ b/package.json
@@ -146,7 +146,6 @@
         ]
     },
     "dependencies": {
-        "is-mobile": "^3.1.1",
-        "youtube-player": "^5.5.2"
+        "is-mobile": "^3.1.1"
     }
 }

--- a/src/YouTubePlayer.ts
+++ b/src/YouTubePlayer.ts
@@ -10,26 +10,36 @@ type EmbedConfig = {
 type PlayerOptions = YT.PlayerOptions & EmbedConfig;
 
 class YouTubePlayer {
+    id: string;
+    playerOptions: PlayerOptions;
     player: YT.Player | undefined;
+    playerInitialized?: Promise<YT.Player>;
 
     constructor(id: string, playerOptions: PlayerOptions) {
-        loadYouTubeIframeApi().then(() => {
-            // TODO what if this.player used before it's defined?
+        this.id = id;
+        this.playerOptions = playerOptions;
+        this.setup();
+    }
+
+    private async setup() {
+        await loadYouTubeIframeApi();
+        return this.getOrInitializePlayer(this.id, this.playerOptions);
+    }
+
+    private getOrInitializePlayer(id: string, playerOptions: PlayerOptions) {
+        if (this.playerInitialized) {
+            return this.playerInitialized;
+        }
+        this.playerInitialized = new Promise<YT.Player>((resolve) => {
             this.player = new YT.Player(id, playerOptions);
+            resolve(this.player);
         });
+        return this.playerInitialized;
     }
-    on(eventName: string, callBack: unknown) {
-        console.log('on', eventName);
-        return () => {
-            console.log("I'm empty");
-        };
-    }
-    getPlayerState() {
-        console.log(
-            'Eachhashingalgorithmgeneratesthesamenumberofbytesirrespectiveoftheplaintextsize',
-        );
-        return 1;
-        // return this.player.getPlayerState();
+
+    async getPlayerState() {
+        const player = await this.setup();
+        return player.getPlayerState();
     }
 }
 

--- a/src/YouTubePlayer.ts
+++ b/src/YouTubePlayer.ts
@@ -1,0 +1,36 @@
+import type { AdsConfig } from '@guardian/commercial-core';
+import loadYouTubeIframeApi from './loadYouTubeIframeApi';
+
+type EmbedConfig = {
+    embedConfig: {
+        relatedChannels: string[];
+        adsConfig: AdsConfig;
+    };
+};
+type PlayerOptions = YT.PlayerOptions & EmbedConfig;
+
+class YouTubePlayer {
+    player: YT.Player | undefined;
+
+    constructor(id: string, playerOptions: PlayerOptions) {
+        loadYouTubeIframeApi().then(() => {
+            // TODO what if this.player used before it's defined?
+            this.player = new YT.Player(id, playerOptions);
+        });
+    }
+    on(eventName: string, callBack: unknown) {
+        console.log('on', eventName);
+        return () => {
+            console.log("I'm empty");
+        };
+    }
+    getPlayerState() {
+        console.log(
+            'Eachhashingalgorithmgeneratesthesamenumberofbytesirrespectiveoftheplaintextsize',
+        );
+        return 1;
+        // return this.player.getPlayerState();
+    }
+}
+
+export { YouTubePlayer };

--- a/src/YouTubePlayer.ts
+++ b/src/YouTubePlayer.ts
@@ -41,6 +41,10 @@ class YouTubePlayer {
         const player = await this.setup();
         return player.getPlayerState();
     }
+    async stopVideo() {
+        const player = await this.setup();
+        player.stopVideo();
+    }
 }
 
 export { YouTubePlayer };

--- a/src/YouTubePlayer.ts
+++ b/src/YouTubePlayer.ts
@@ -1,5 +1,5 @@
 import type { AdsConfig } from '@guardian/commercial-core';
-import loadYouTubeIframeApi from './loadYouTubeIframeApi';
+import { loadYouTubeAPI } from './loadYouTubeIframeApi';
 
 type EmbedConfig = {
     embedConfig: {
@@ -22,7 +22,7 @@ class YouTubePlayer {
     }
 
     private async setup() {
-        await loadYouTubeIframeApi();
+        await loadYouTubeAPI();
         return this.getOrInitializePlayer(this.id, this.playerOptions);
     }
 

--- a/src/YouTubePlayer.ts
+++ b/src/YouTubePlayer.ts
@@ -7,42 +7,32 @@ type EmbedConfig = {
         adsConfig: AdsConfig;
     };
 };
+
 type PlayerOptions = YT.PlayerOptions & EmbedConfig;
 
 class YouTubePlayer {
-    id: string;
-    playerOptions: PlayerOptions;
-    player: YT.Player | undefined;
-    playerInitialized?: Promise<YT.Player>;
+    playerPromise: Promise<YT.Player>;
 
     constructor(id: string, playerOptions: PlayerOptions) {
-        this.id = id;
-        this.playerOptions = playerOptions;
-        this.setup();
+        this.playerPromise = this.setPlayer(id, playerOptions);
     }
 
-    private async setup() {
-        await loadYouTubeAPI();
-        return this.getOrInitializePlayer(this.id, this.playerOptions);
-    }
-
-    private getOrInitializePlayer(id: string, playerOptions: PlayerOptions) {
-        if (this.playerInitialized) {
-            return this.playerInitialized;
-        }
-        this.playerInitialized = new Promise<YT.Player>((resolve) => {
-            this.player = new YT.Player(id, playerOptions);
-            resolve(this.player);
+    private async setPlayer(id: string, playerOptions: PlayerOptions) {
+        const YTAPI = await loadYouTubeAPI();
+        const playerPromise = new Promise<YT.Player>((resolve) => {
+            const player = new YTAPI.Player(id, playerOptions);
+            resolve(player);
         });
-        return this.playerInitialized;
+        return playerPromise;
     }
 
     async getPlayerState() {
-        const player = await this.setup();
+        const player = await this.playerPromise;
         return player.getPlayerState();
     }
+
     async stopVideo() {
-        const player = await this.setup();
+        const player = await this.playerPromise;
         player.stopVideo();
     }
 }

--- a/src/YoutubeAtom.stories.tsx
+++ b/src/YoutubeAtom.stories.tsx
@@ -341,7 +341,7 @@ export const MultipleVideos = (): JSX.Element => {
             />
             <YoutubeAtom
                 elementId="xyz-2"
-                videoId="-ZCvZmYlQD8"
+                videoId="pcMiS6PW8aQ"
                 alt=""
                 role="inline"
                 eventEmitters={[

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -319,8 +319,8 @@ export const YoutubeAtomPlayer = ({
                 ) => {
                     if (event instanceof CustomEvent) {
                         if (event.detail.uniqueId !== uniqueId) {
-                            // const playerStatePromise =
-                            //     player.current?.getPlayerState();
+                            const playerStatePromise =
+                                player.current?.getPlayerState();
                             // playerStatePromise?.then((state) => {
                             //     if (state === YT.PlayerState.PLAYING) {
                             //         player.current?.stopVideo();

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -322,7 +322,7 @@ export const YoutubeAtomPlayer = ({
                             const playerStatePromise =
                                 player.current?.getPlayerState();
                             playerStatePromise?.then((state) => {
-                                if (state === YT.PlayerState.PLAYING) {
+                                if (state && state === YT.PlayerState.PLAYING) {
                                     player.current?.stopVideo();
                                 }
                             });

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -277,11 +277,6 @@ export const YoutubeAtomPlayer = ({
                               consentState,
                           );
 
-                /**
-                 * We use the wrapper library youtube-player: https://github.com/gajus/youtube-player
-                 * It will load the iframe embed
-                 * It's API allows us to queue up calls to YT that will fire when the underlying player is ready
-                 */
                 player.current = new YouTubePlayer(id, {
                     height: width,
                     width: height,

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -321,11 +321,11 @@ export const YoutubeAtomPlayer = ({
                         if (event.detail.uniqueId !== uniqueId) {
                             const playerStatePromise =
                                 player.current?.getPlayerState();
-                            // playerStatePromise?.then((state) => {
-                            //     if (state === YT.PlayerState.PLAYING) {
-                            //         player.current?.stopVideo();
-                            //     }
-                            // });
+                            playerStatePromise?.then((state) => {
+                                if (state === YT.PlayerState.PLAYING) {
+                                    player.current?.stopVideo();
+                                }
+                            });
                         }
                     }
                 };
@@ -363,9 +363,9 @@ export const YoutubeAtomPlayer = ({
          *
          * 'stopVideo' is controlled by the close sticky video button
          */
-        // if (stopVideo) {
-        //     player.current?.stopVideo();
-        // }
+        if (stopVideo) {
+            player.current?.stopVideo();
+        }
     }, [stopVideo]);
 
     /**

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -316,8 +316,11 @@ export const YoutubeAtomPlayer = ({
                         if (event.detail.uniqueId !== uniqueId) {
                             const playerStatePromise =
                                 player.current?.getPlayerState();
-                            playerStatePromise?.then((state) => {
-                                if (state && state === YT.PlayerState.PLAYING) {
+                            playerStatePromise?.then((playerState) => {
+                                if (
+                                    playerState &&
+                                    playerState === YT.PlayerState.PLAYING
+                                ) {
                                     player.current?.stopVideo();
                                 }
                             });

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -25,12 +25,6 @@ type Props = {
     stopVideo: boolean;
 };
 
-declare global {
-    interface Window {
-        onYouTubeIframeAPIReady: unknown;
-    }
-}
-
 type YoutubeCallback = (e: YT.PlayerEvent & YT.OnStateChangeEvent) => void;
 
 type CustomPlayEventDetail = { videoId: string };

--- a/src/loadYouTubeIframeApi.ts
+++ b/src/loadYouTubeIframeApi.ts
@@ -7,11 +7,7 @@ declare global {
 }
 
 const loadScripts = () => {
-    const scripts = [
-        loadScript('https://www.youtube.com/iframe_api?ima=1'),
-        // TODO only load if enableIma
-        loadScript('//imasdk.googleapis.com/js/sdkloader/ima3.js'),
-    ];
+    const scripts = [loadScript('https://www.youtube.com/iframe_api')];
     return Promise.all(scripts);
 };
 

--- a/src/loadYouTubeIframeApi.ts
+++ b/src/loadYouTubeIframeApi.ts
@@ -9,6 +9,7 @@ declare global {
 const loadScripts = () => {
     const scripts = [
         loadScript('https://www.youtube.com/iframe_api?ima=1'),
+        // TODO only load if enableIma
         loadScript('//imasdk.googleapis.com/js/sdkloader/ima3.js'),
     ];
     return Promise.all(scripts);

--- a/src/loadYouTubeIframeApi.ts
+++ b/src/loadYouTubeIframeApi.ts
@@ -1,0 +1,49 @@
+import { loadScript } from '@guardian/libs';
+
+declare global {
+    interface Window {
+        onYouTubeIframeAPIReady: () => void;
+    }
+}
+
+const loadScripts = () => {
+    const scripts = [
+        loadScript('https://www.youtube.com/iframe_api?ima=1'),
+        loadScript('//imasdk.googleapis.com/js/sdkloader/ima3.js'),
+    ];
+    return Promise.all(scripts);
+};
+
+export default (): Promise<typeof YT> => {
+    /**
+     * A promise that is resolved when window.onYouTubeIframeAPIReady is called.
+     * The promise is resolved with a reference to window.YT object.
+     */
+    const iframeAPIReady = new Promise<typeof YT>((resolve) => {
+        if (
+            window.YT &&
+            window.YT.Player &&
+            window.YT.Player instanceof Function
+        ) {
+            resolve(window.YT);
+
+            return;
+        }
+
+        const previous = window.onYouTubeIframeAPIReady;
+
+        loadScripts().then(() => {
+            // The API will call this function when page has finished downloading
+            // the JavaScript for the player API.
+            window.onYouTubeIframeAPIReady = () => {
+                if (previous) {
+                    previous();
+                }
+
+                resolve(window.YT);
+            };
+        });
+    });
+
+    return iframeAPIReady;
+};

--- a/src/loadYouTubeIframeApi.ts
+++ b/src/loadYouTubeIframeApi.ts
@@ -6,44 +6,55 @@ declare global {
     }
 }
 
+let scriptsPromise: Promise<(Event | undefined)[]>;
+let youtubeAPIReadyPromise: Promise<typeof YT>;
+
 const loadScripts = () => {
-    const scripts = [loadScript('https://www.youtube.com/iframe_api')];
-    return Promise.all(scripts);
+    /**
+     * Since loadScripts can be called multiple times on the same page for pages with more than one video,
+     * only attempt to load the scripts if this is the first call and return a promise if we're on a subsequent call.
+     */
+    if (scriptsPromise) {
+        return scriptsPromise;
+    }
+    const scripts = [
+        // keep array multi-line
+        loadScript('https://www.youtube.com/iframe_api'),
+    ];
+    scriptsPromise = Promise.all(scripts);
+    return scriptsPromise;
+};
+
+/**
+ * The YouTube IFrame API will call `window.onYouTubeIframeAPIReady`
+ * when it has downloaded and is ready
+ */
+const youtubeAPIReady = () => {
+    /**
+     * Since youtubeAPIReady can be called multiple times on the same page for pages with more than one video,
+     * only overwrite window.onYouTubeIframeAPIReady if this is the first call and return a promise
+     * if we're on a subsequent call.
+     */
+    if (youtubeAPIReadyPromise) {
+        return youtubeAPIReadyPromise;
+    }
+    youtubeAPIReadyPromise = new Promise((resolve) => {
+        window.onYouTubeIframeAPIReady = () => {
+            resolve(window.YT);
+        };
+    });
+    return youtubeAPIReadyPromise;
 };
 
 const loadYouTubeAPI = (): Promise<typeof YT> => {
-    /**
-     * A promise that is resolves when the YouTube IFrame API is loaded
-     * and ready with a reference to window.YT
-     */
-    const youTubeAPIPromise = new Promise<typeof YT>((resolve) => {
-        if (
-            window.YT &&
-            window.YT.Player &&
-            window.YT.Player instanceof Function
-        ) {
-            resolve(window.YT);
-            return;
-        }
+    // if another part of the code has already loaded youtube api, return early
+    if (window.YT && window.YT.Player && window.YT.Player instanceof Function) {
+        return Promise.resolve(window.YT);
+    }
 
-        const previous = window.onYouTubeIframeAPIReady;
-
-        loadScripts().then(() => {
-            /**
-             * The YouTube IFrame API will call `window.onYouTubeIframeAPIReady`
-             * when it has downloaded and is ready
-             */
-            window.onYouTubeIframeAPIReady = () => {
-                if (previous) {
-                    previous();
-                }
-
-                resolve(window.YT);
-            };
-        });
+    return loadScripts().then(() => {
+        return youtubeAPIReady();
     });
-
-    return youTubeAPIPromise;
 };
 
 export { loadYouTubeAPI };

--- a/src/loadYouTubeIframeApi.ts
+++ b/src/loadYouTubeIframeApi.ts
@@ -13,8 +13,8 @@ const loadScripts = () => {
 
 export default (): Promise<typeof YT> => {
     /**
-     * A promise that is resolved when window.onYouTubeIframeAPIReady is called.
-     * The promise is resolved with a reference to window.YT object.
+     * A promise that is resolves when the YouTube IFrame API is loaded
+     * and ready with a reference to window.YT
      */
     const iframeAPIReady = new Promise<typeof YT>((resolve) => {
         if (
@@ -23,15 +23,16 @@ export default (): Promise<typeof YT> => {
             window.YT.Player instanceof Function
         ) {
             resolve(window.YT);
-
             return;
         }
 
         const previous = window.onYouTubeIframeAPIReady;
 
         loadScripts().then(() => {
-            // The API will call this function when page has finished downloading
-            // the JavaScript for the player API.
+            /**
+             * The YouTube IFrame API will call `window.onYouTubeIframeAPIReady`
+             * when it has downloaded and is ready
+             */
             window.onYouTubeIframeAPIReady = () => {
                 if (previous) {
                     previous();

--- a/src/loadYouTubeIframeApi.ts
+++ b/src/loadYouTubeIframeApi.ts
@@ -11,12 +11,12 @@ const loadScripts = () => {
     return Promise.all(scripts);
 };
 
-export default (): Promise<typeof YT> => {
+const loadYouTubeAPI = (): Promise<typeof YT> => {
     /**
      * A promise that is resolves when the YouTube IFrame API is loaded
      * and ready with a reference to window.YT
      */
-    const iframeAPIReady = new Promise<typeof YT>((resolve) => {
+    const youTubeAPIPromise = new Promise<typeof YT>((resolve) => {
         if (
             window.YT &&
             window.YT.Player &&
@@ -43,5 +43,7 @@ export default (): Promise<typeof YT> => {
         });
     });
 
-    return iframeAPIReady;
+    return youTubeAPIPromise;
 };
+
+export { loadYouTubeAPI };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5832,7 +5832,7 @@ date-format@0.0.2:
   resolved "https://registry.yarnpkg.com/date-format/-/date-format-0.0.2.tgz#fafd448f72115ef1e2b739155ae92f2be6c28dd1"
   integrity sha1-+v1Ej3IRXvHitzkVWukvK+bCjdE=
 
-debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6, debug@^2.6.9:
+debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -9924,11 +9924,6 @@ listr@0.14.3, listr@^0.14.3:
     p-map "^2.0.0"
     rxjs "^6.3.3"
 
-load-script@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/load-script/-/load-script-1.0.0.tgz#0491939e0bee5643ee494a7e3da3d2bac70c6ca4"
-  integrity sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ=
-
 load-yaml-file@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/load-yaml-file/-/load-yaml-file-0.2.0.tgz#af854edaf2bea89346c07549122753c07372f64d"
@@ -13103,11 +13098,6 @@ signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
-sister@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/sister/-/sister-3.0.2.tgz#bb3e39f07b1f75bbe1945f29a27ff1e5a2f26be4"
-  integrity sha512-p19rtTs+NksBRKW9qn0UhZ8/TUI9BPw9lmtHny+Y3TinWlOa9jWh9xB0AtPSdmOy49NJJJSSe0Ey4C7h0TrcYA==
-
 sisteransi@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
@@ -15023,15 +15013,6 @@ yarn-or-npm@^3.0.1:
   dependencies:
     cross-spawn "^6.0.5"
     pkg-dir "^4.2.0"
-
-youtube-player@^5.5.2:
-  version "5.5.2"
-  resolved "https://registry.yarnpkg.com/youtube-player/-/youtube-player-5.5.2.tgz#052b86b1eabe21ff331095ffffeae285fa7f7cb5"
-  integrity sha512-ZGtsemSpXnDky2AUYWgxjaopgB+shFHgXVpiJFeNB5nWEugpW1KWYDaHKuLqh2b67r24GtP6HoSW5swvf0fFIQ==
-  dependencies:
-    debug "^2.6.6"
-    load-script "^1.0.0"
-    sister "^3.0.0"
 
 zwitch@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
## What does this change?
- Removes [`youtube-player`](https://www.npmjs.com/package/youtube-player) from the project dependencies and replaces it with 
   - `loadYouTubeIframeApi` function to load the Youtube iframe api script
   -  our own `YouTubePlayer` class which acts as a wrapper over the YouTube Iframe API's player object and "promisifies" the player methods so that they're executed only when the player is ready, much like `youtube-player` does.
- Small change to YoutubeAtom MultipleVideos story so that it includes three different videos 
- Removes 11.2kB / 4.2kB gzip from bundled dependencies

## Why?
- In a subsequent PR we'd like to make a change to `loadYouTubeIframeApi` to enable us to create an experiment to test [interactive media ads](https://developers.google.com/interactive-media-ads) on first-party videos. In order to do this we'll need to modify `loadYouTubeIframeApi` so that it loads an additional script.

## How to test
- [x] Run `yarn storybook` to start storybook and check that the behavior of the `YoutubeAtom` hasn't changed
- [x] link to DCR locally to sense check that youtube players behave as expected
- [ ] release and test DCR in CODE to confirm that players behave as expected