### PR TITLE
Update readme with correct naming for changesets release PR

### DIFF
--- a/.changeset/fifty-lies-explode.md
+++ b/.changeset/fifty-lies-explode.md
@@ -1,0 +1,5 @@
+---
+'@guardian/atoms-rendering': patch
+---
+
+Update readme with correct name for changesets auto generated PR

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ An example PR for adding the Profile Atom can be found [here](https://github.com
 
 Generate a changeset describing your work by running `yarn changeset` and following the prompts.
 
-Publishing is triggered by merging the auto-generated Version Packages PR that changesets manages.
+Publishing is triggered by merging the auto-generated Bump Version PR that changesets manages.
 
 Once complete, you can update the version of `@guardian/atoms-rendering` in any consuming project to see the changes.
 


### PR DESCRIPTION
## What does this change?

Corrects name of auto generated changesets PR in readme.