### PR TITLE
YoutubeAtomPlayer removes YouTube event listeners before unmount

### DIFF
--- a/.changeset/mean-ducks-float.md
+++ b/.changeset/mean-ducks-float.md
@@ -1,0 +1,5 @@
+---
+'@guardian/atoms-rendering': patch
+---
+
+YoutubeAtomPlayer removes YouTube event listeners before unmount

--- a/src/YouTubePlayer.ts
+++ b/src/YouTubePlayer.ts
@@ -12,7 +12,7 @@ type EmbedConfig = {
 type PlayerOptions = YT.PlayerOptions & EmbedConfig;
 
 // PlayerEvent, OnStateChangeEvent, etc.
-type YouTubeEventListenerName = keyof YT.Events;
+type PlayerListenerName = keyof YT.Events;
 
 class YouTubePlayer {
     playerPromise: Promise<YT.Player>;
@@ -57,7 +57,7 @@ class YouTubePlayer {
     }
 
     removeEventListener<T extends YT.PlayerEvent>(
-        eventName: YouTubeEventListenerName,
+        eventName: PlayerListenerName,
         listener: YT.PlayerEventHandler<T>,
     ): void {
         /**
@@ -69,4 +69,4 @@ class YouTubePlayer {
     }
 }
 
-export { YouTubePlayer, YouTubeEventListenerName };
+export { YouTubePlayer, PlayerListenerName };

--- a/src/YouTubePlayer.ts
+++ b/src/YouTubePlayer.ts
@@ -11,8 +11,12 @@ type EmbedConfig = {
 
 type PlayerOptions = YT.PlayerOptions & EmbedConfig;
 
+// PlayerEvent, OnStateChangeEvent, etc.
+type YouTubeEventListenerName = keyof YT.Events;
+
 class YouTubePlayer {
     playerPromise: Promise<YT.Player>;
+    private _player?: YT.Player;
 
     constructor(id: string, playerOptions: PlayerOptions) {
         this.playerPromise = this.setPlayer(id, playerOptions);
@@ -22,8 +26,8 @@ class YouTubePlayer {
         const YTAPI = await loadYouTubeAPI();
         const playerPromise = new Promise<YT.Player>((resolve, reject) => {
             try {
-                const player = new YTAPI.Player(id, playerOptions);
-                resolve(player);
+                this._player = new YTAPI.Player(id, playerOptions);
+                resolve(this._player);
             } catch (e) {
                 this.logError(e as Error);
                 reject(e);
@@ -51,6 +55,18 @@ class YouTubePlayer {
             })
             .catch(this.logError);
     }
+
+    removeEventListener<T extends YT.PlayerEvent>(
+        eventName: YouTubeEventListenerName,
+        listener: YT.PlayerEventHandler<T>,
+    ): void {
+        /**
+         * If the YouTube API hasn't finished loading,
+         * this._player may be undefined in which case removeEventListener
+         * will fail silently.
+         */
+        this._player?.removeEventListener<T>(eventName, listener);
+    }
 }
 
-export { YouTubePlayer };
+export { YouTubePlayer, YouTubeEventListenerName };

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useRef } from 'react';
-import { YouTubePlayer } from './YouTubePlayer';
+import React, { useEffect, useLayoutEffect, useRef } from 'react';
+import { YouTubeEventListenerName, YouTubePlayer } from './YouTubePlayer';
 
 import type { AdTargeting, VideoEventKey } from './types';
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
@@ -35,6 +35,13 @@ type ProgressEvents = {
     hasSent75Event: boolean;
     hasSentEndEvent: boolean;
 };
+
+type PlayerListenerItem<T extends YouTubeEventListenerName> = {
+    name: T;
+    listener: NonNullable<YT.Events[T]>;
+};
+
+type PlayerListeners = Array<PlayerListenerItem<YouTubeEventListenerName>>;
 
 /**
  * ProgressEvents are a ref, see below

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -36,17 +36,22 @@ type ProgressEvents = {
     hasSentEndEvent: boolean;
 };
 
+/**
+ *  E.g.
+ *  name: onReady, onStateChange, etc...
+ *  listener: YT.PlayerEventHandler<PlayerEvent>, YT.PlayerEventHandler<OnStateChangeEvent>
+ */
 type PlayerListener<T extends PlayerListenerName> = {
-    // onReady, onStateChange, etc.
     name: T;
-    // PlayerEventHandler<PlayerEvent>,  PlayerEventHandler<OnStateChangeEvent>
     listener: NonNullable<YT.Events[T]>;
 };
 
 type PlayerListeners = Array<PlayerListener<PlayerListenerName>>;
 
-// Given a PlayerEventHandler, (e.g. PlayerEventHandler<OnStateChangeEvent>)
-// return its event type (e.g. OnStateChangeEvent)
+/**
+ * Given a YT.PlayerEventHandler, (e.g. PlayerEventHandler<OnStateChangeEvent>)
+ * return its event type (e.g. OnStateChangeEvent)
+ */
 type ExtractEventType<T> = T extends YT.PlayerEventHandler<infer X> ? X : never;
 
 /**

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -305,11 +305,6 @@ export const YoutubeAtomPlayer = ({
                     eventEmitters,
                 );
 
-                const test: Array<PlayerListenerItem<keyof YT.Events>> = [
-                    { name: 'onReady', listener: onReadyListener },
-                ];
-                console.log(test);
-
                 player.current = new YouTubePlayer(id, {
                     height: width,
                     width: height,

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -397,8 +397,14 @@ export const YoutubeAtomPlayer = ({
         /**
          * Unregister listeners before component unmount
          *
-         * A useLayoutEffect with an empty dependency array will
-         * call its cleanup before unmount.
+         * An empty dependency array will call its cleanup on unmount.
+         *
+         * Use useLayoutEffect to ensure the cleanup function is run
+         * before the component is removed from the DOM. Usually clean up
+         * functions will run after the render and commit phase.
+         *
+         * If we attempt to unregister listeners after the component is
+         * removed from the DOM the YouTube API logs a warning to the console.
          */
         return () => {
             playerListeners.current.forEach((playerListener) => {

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useLayoutEffect, useRef } from 'react';
-import { YouTubeEventListenerName, YouTubePlayer } from './YouTubePlayer';
+import { PlayerListenerName, YouTubePlayer } from './YouTubePlayer';
 
 import type { AdTargeting, VideoEventKey } from './types';
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
@@ -36,14 +36,14 @@ type ProgressEvents = {
     hasSentEndEvent: boolean;
 };
 
-type PlayerListenerItem<T extends YouTubeEventListenerName> = {
+type PlayerListener<T extends PlayerListenerName> = {
     // onReady, onStateChange, etc.
     name: T;
     // PlayerEventHandler<PlayerEvent>,  PlayerEventHandler<OnStateChangeEvent>
     listener: NonNullable<YT.Events[T]>;
 };
 
-type PlayerListeners = Array<PlayerListenerItem<YouTubeEventListenerName>>;
+type PlayerListeners = Array<PlayerListener<PlayerListenerName>>;
 
 // Given a PlayerEventHandler, (e.g. PlayerEventHandler<OnStateChangeEvent>)
 // return its event type (e.g. OnStateChangeEvent)

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -37,11 +37,17 @@ type ProgressEvents = {
 };
 
 type PlayerListenerItem<T extends YouTubeEventListenerName> = {
+    // onReady, onStateChange, etc.
     name: T;
+    // PlayerEventHandler<PlayerEvent>,  PlayerEventHandler<OnStateChangeEvent>
     listener: NonNullable<YT.Events[T]>;
 };
 
 type PlayerListeners = Array<PlayerListenerItem<YouTubeEventListenerName>>;
+
+// Given a PlayerEventHandler, (e.g. PlayerEventHandler<OnStateChangeEvent>)
+// return its event type (e.g. OnStateChangeEvent)
+type ExtractEventType<T> = T extends YT.PlayerEventHandler<infer X> ? X : never;
 
 /**
  * ProgressEvents are a ref, see below
@@ -400,10 +406,6 @@ export const YoutubeAtomPlayer = ({
          * call its cleanup before unmount.
          */
         return () => {
-            type ExtractEventType<T> = T extends YT.PlayerEventHandler<infer X>
-                ? X
-                : never;
-
             playerListeners.current.forEach((playerListener) => {
                 type T = ExtractEventType<typeof playerListener.name>;
                 player.current?.removeEventListener<T>(


### PR DESCRIPTION
## What does this change?
- Introduces an improvement to the `YoutubeAtomPlayer` component to remove event listeners from the `YT. Player` object before `YoutubeAtomPlayer` unmounts.

## How to test
- [x] run storybook locally. Switching from one YoutubeAtom story to another unmounts the YoutubeAtom component each time.
- [ ] release this change, create a new branch on DCR which upgrades to the new version, deploy this branch to CODE and verify on [a page with multiple Youtube Atoms](https://m.code.dev-theguardian.com/world/live/2022/mar/28/russia-ukraine-war-latest-news-zelenskiy-putin-live-updates) that their listeners are removed when the players unmount.


