### PR TITLE
Fix: prevent race condition in `loadYouTubeAPI`

### DIFF
--- a/.changeset/slimy-starfishes-judge.md
+++ b/.changeset/slimy-starfishes-judge.md
@@ -1,0 +1,5 @@
+---
+'@guardian/atoms-rendering': patch
+---
+
+Fix potential race in loadYouTubeAPI


### PR DESCRIPTION
## What does this change?
- `loadYouTubeAPI` and the [equivalent function in `youtube-player`](https://github.com/gajus/youtube-player/blob/master/src/loadYouTubeIframeApi.js#L9) that we replaced in #434 have a bug which causes a potential race condition. Since the youtube iframe api script is loaded before `window.onYouTubeIframeAPIReady` is defined, there is a possibility that the script will finish loading, the youtube api will be "ready", and the ready function will be called before it's defined. If this happens, the promise returned by `loadYouTubeAPI` never resolves and `YoutubeAtomPlayer` isn't made aware of the fact that the player is ready. For players with an overlay, the placeholder is never removed and the YoutubeAtom component appears as a black rectangle.
- This PR removes the race condition by defining `window.onYouTubeIframeAPIReady` before the script is loaded, guaranteeing that the function can't be called before it is defined.
- Although in theory this failure mode is possible on `main` at the moment, in practice it doesn't occur because `onYouTubeIframeAPIReady` is consistently defined before the youtube api is ready. Only when a second script is loaded as in #447 does the failure occur, and then only rarely.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to reproduce the error
- to reproduce the failure mode on `main`, add a timeout of 5 seconds to the list of `scripts` loaded in `loadScripts`, simulating a second script which takes a long time to fetch and run.
```
new Promise((resolve) => {
    setTimeout(() => resolve, 5000);
}),
```
- the youtube script finishes loading and calls `window.onYouTubeIframeAPIReady` before `_scriptsPromise` resolves and before `youtubeAPIReady` is called to define `window.onYouTubeIframeAPIReady`