### PR TITLE
YoutubeAtom - Pause video rather than stop

### DIFF
--- a/.changeset/wise-lemons-rule.md
+++ b/.changeset/wise-lemons-rule.md
@@ -1,0 +1,5 @@
+---
+'@guardian/atoms-rendering': minor
+---
+
+YoutubeAtom - Pause video rather than stop

--- a/src/YouTubePlayer.ts
+++ b/src/YouTubePlayer.ts
@@ -48,6 +48,14 @@ class YouTubePlayer {
             .catch(this.logError);
     }
 
+    pauseVideo(): Promise<void> {
+        return this.playerPromise
+            .then((player) => {
+                player.pauseVideo();
+            })
+            .catch(this.logError);
+    }
+
     stopVideo(): Promise<void> {
         return this.playerPromise
             .then((player) => {

--- a/src/YoutubeAtom.stories.tsx
+++ b/src/YoutubeAtom.stories.tsx
@@ -319,9 +319,9 @@ export const DuplicateVideos = (): JSX.Element => {
     );
 };
 
-export const MultipleVideos = (): JSX.Element => {
+export const MultipleStickyVideos = (): JSX.Element => {
     return (
-        <div style={{ width: '500px' }}>
+        <div style={{ width: '500px', height: '5000px' }}>
             <YoutubeAtom
                 elementId="xyz"
                 videoId="-ZCvZmYlQD8"

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -67,6 +67,7 @@ export const YoutubeAtom = ({
     const playerState = (videoEvent: VideoEventKey) => {
         switch (videoEvent) {
             case 'play':
+            case 'resume':
                 setPauseVideo(false);
                 setIsActive(true);
                 break;
@@ -150,6 +151,9 @@ export const YoutubeAtom = ({
                         autoPlay={hasOverlay}
                         onReady={playerReadyCallback}
                         pauseVideo={pauseVideo}
+                        deactivateVideo={() => {
+                            setIsActive(false);
+                        }}
                     />
                 )}
                 {showOverlay && (

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -55,6 +55,7 @@ export const YoutubeAtom = ({
     const [overlayClicked, setOverlayClicked] = useState<boolean>(false);
     const [playerReady, setPlayerReady] = useState<boolean>(false);
     const [isActive, setIsActive] = useState<boolean>(false);
+    const [isClosed, setIsClosed] = useState<boolean>(false);
     const [pauseVideo, setPauseVideo] = useState<boolean>(false);
 
     const uniqueId = `${videoId}-${elementId}`;
@@ -69,6 +70,7 @@ export const YoutubeAtom = ({
             case 'play':
             case 'resume':
                 setPauseVideo(false);
+                setIsClosed(false);
                 setIsActive(true);
                 break;
             case 'end':
@@ -131,6 +133,8 @@ export const YoutubeAtom = ({
             eventEmitters={eventEmitters}
             setPauseVideo={() => setPauseVideo(true)}
             isMainMedia={isMainMedia}
+            isClosed={isClosed}
+            setIsClosed={setIsClosed}
         >
             <MaintainAspectRatio height={height} width={width}>
                 {loadPlayer && consentState && (

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -54,13 +54,13 @@ export const YoutubeAtom = ({
 }: Props): JSX.Element => {
     const [overlayClicked, setOverlayClicked] = useState<boolean>(false);
     const [playerReady, setPlayerReady] = useState<boolean>(false);
-    const [hasStarted, setHasStarted] = useState<boolean>(false);
+    const [isActive, setIsActive] = useState<boolean>(false);
     const [pauseVideo, setPauseVideo] = useState<boolean>(false);
 
     const uniqueId = `${videoId}-${elementId}`;
 
     /**
-     * Update the hasStarted state based on video events
+     * Update the isActive state based on video events
      *
      * @param {VideoEventKey} videoEvent the video event which triggers the callback
      */
@@ -68,11 +68,11 @@ export const YoutubeAtom = ({
         switch (videoEvent) {
             case 'play':
                 setPauseVideo(false);
-                setHasStarted(true);
+                setIsActive(true);
                 break;
             case 'end':
             case 'cued':
-                setHasStarted(false);
+                setIsActive(false);
                 break;
         }
     };
@@ -126,7 +126,7 @@ export const YoutubeAtom = ({
         <YoutubeAtomSticky
             videoId={videoId}
             shouldStick={shouldStick}
-            hasStarted={hasStarted}
+            isActive={isActive}
             eventEmitters={eventEmitters}
             setPauseVideo={() => setPauseVideo(true)}
             isMainMedia={isMainMedia}

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -54,13 +54,13 @@ export const YoutubeAtom = ({
 }: Props): JSX.Element => {
     const [overlayClicked, setOverlayClicked] = useState<boolean>(false);
     const [playerReady, setPlayerReady] = useState<boolean>(false);
-    const [isPlaying, setIsPlaying] = useState<boolean>(false);
+    const [hasStarted, setHasStarted] = useState<boolean>(false);
     const [stopVideo, setStopVideo] = useState<boolean>(false);
 
     const uniqueId = `${videoId}-${elementId}`;
 
     /**
-     * Update the isPlaying state based on video events
+     * Update the hasStarted state based on video events
      *
      * @param {VideoEventKey} videoEvent the video event which triggers the callback
      */
@@ -68,11 +68,11 @@ export const YoutubeAtom = ({
         switch (videoEvent) {
             case 'play':
                 setStopVideo(false);
-                setIsPlaying(true);
+                setHasStarted(true);
                 break;
             case 'end':
             case 'cued':
-                setIsPlaying(false);
+                setHasStarted(false);
                 break;
         }
     };
@@ -126,7 +126,7 @@ export const YoutubeAtom = ({
         <YoutubeAtomSticky
             videoId={videoId}
             shouldStick={shouldStick}
-            isPlaying={isPlaying}
+            hasStarted={hasStarted}
             eventEmitters={eventEmitters}
             onStopVideo={() => setStopVideo(true)}
             isMainMedia={isMainMedia}

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -127,6 +127,7 @@ export const YoutubeAtom = ({
 
     return (
         <YoutubeAtomSticky
+            uniqueId={uniqueId}
             videoId={videoId}
             shouldStick={shouldStick}
             isActive={isActive}

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -55,7 +55,7 @@ export const YoutubeAtom = ({
     const [overlayClicked, setOverlayClicked] = useState<boolean>(false);
     const [playerReady, setPlayerReady] = useState<boolean>(false);
     const [hasStarted, setHasStarted] = useState<boolean>(false);
-    const [stopVideo, setStopVideo] = useState<boolean>(false);
+    const [pauseVideo, setPauseVideo] = useState<boolean>(false);
 
     const uniqueId = `${videoId}-${elementId}`;
 
@@ -67,7 +67,7 @@ export const YoutubeAtom = ({
     const playerState = (videoEvent: VideoEventKey) => {
         switch (videoEvent) {
             case 'play':
-                setStopVideo(false);
+                setPauseVideo(false);
                 setHasStarted(true);
                 break;
             case 'end':
@@ -128,7 +128,7 @@ export const YoutubeAtom = ({
             shouldStick={shouldStick}
             hasStarted={hasStarted}
             eventEmitters={eventEmitters}
-            onStopVideo={() => setStopVideo(true)}
+            setPauseVideo={() => setPauseVideo(true)}
             isMainMedia={isMainMedia}
         >
             <MaintainAspectRatio height={height} width={width}>
@@ -149,7 +149,7 @@ export const YoutubeAtom = ({
                          */
                         autoPlay={hasOverlay}
                         onReady={playerReadyCallback}
-                        stopVideo={stopVideo}
+                        pauseVideo={pauseVideo}
                     />
                 )}
                 {showOverlay && (

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -331,9 +331,9 @@ export const YoutubeAtomPlayer = ({
                 });
 
                 /**
-                 * Stop the current video when another video is played on the same page
+                 * Pause the current video when another video is played on the same page
                  */
-                const handleStopVideo = (
+                const handlePauseVideo = (
                     event: CustomEventInit<CustomPlayEventDetail>,
                 ) => {
                     if (event instanceof CustomEvent) {
@@ -345,7 +345,7 @@ export const YoutubeAtomPlayer = ({
                                     playerState &&
                                     playerState === YT.PlayerState.PLAYING
                                 ) {
-                                    player.current?.stopVideo();
+                                    player.current?.pauseVideo();
                                 }
                             });
                         }
@@ -355,9 +355,12 @@ export const YoutubeAtomPlayer = ({
                 /**
                  * add listener for custom play event
                  */
-                document.addEventListener(customPlayEventName, handleStopVideo);
+                document.addEventListener(
+                    customPlayEventName,
+                    handlePauseVideo,
+                );
 
-                customListeners.current[customPlayEventName] = handleStopVideo;
+                customListeners.current[customPlayEventName] = handlePauseVideo;
 
                 playerListeners.current.push(
                     { name: 'onReady', listener: onReadyListener },

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -331,9 +331,9 @@ export const YoutubeAtomPlayer = ({
                 });
 
                 /**
-                 * Pause the current video when another video is played on the same page
+                 * Pause the current video when another video is played
                  */
-                const handlePauseVideo = (
+                const handleCustomPlayEvent = (
                     event: CustomEventInit<CustomPlayEventDetail>,
                 ) => {
                     if (event instanceof CustomEvent) {
@@ -357,10 +357,11 @@ export const YoutubeAtomPlayer = ({
                  */
                 document.addEventListener(
                     customPlayEventName,
-                    handlePauseVideo,
+                    handleCustomPlayEvent,
                 );
 
-                customListeners.current[customPlayEventName] = handlePauseVideo;
+                customListeners.current[customPlayEventName] =
+                    handleCustomPlayEvent;
 
                 playerListeners.current.push(
                     { name: 'onReady', listener: onReadyListener },

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -22,7 +22,7 @@ type Props = {
     eventEmitters: ((event: VideoEventKey) => void)[];
     autoPlay: boolean;
     onReady: () => void;
-    stopVideo: boolean;
+    pauseVideo: boolean;
 };
 
 type CustomPlayEventDetail = { videoId: string };
@@ -250,7 +250,7 @@ export const YoutubeAtomPlayer = ({
     eventEmitters,
     autoPlay,
     onReady,
-    stopVideo,
+    pauseVideo,
 }: Props): JSX.Element => {
     /**
      * useRef for player and progressEvents
@@ -382,18 +382,18 @@ export const YoutubeAtomPlayer = ({
     );
 
     /**
-     * Player stop useEffect
+     * Player pause useEffect
      */
     useEffect(() => {
         /**
-         * if the 'stopVideo' prop is true this should stop the video
+         * if the 'pauseVideo' prop is true this should pause the video
          *
-         * 'stopVideo' is controlled by the close sticky video button
+         * 'pauseVideo' is controlled by the close sticky video button
          */
-        if (stopVideo) {
-            player.current?.stopVideo();
+        if (pauseVideo) {
+            player.current?.pauseVideo();
         }
-    }, [stopVideo]);
+    }, [pauseVideo]);
 
     /**
      * Unregister listeners useLayoutEffect

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -23,6 +23,7 @@ type Props = {
     autoPlay: boolean;
     onReady: () => void;
     pauseVideo: boolean;
+    deactivateVideo: () => void;
 };
 
 type CustomPlayEventDetail = { videoId: string };
@@ -251,6 +252,7 @@ export const YoutubeAtomPlayer = ({
     autoPlay,
     onReady,
     pauseVideo,
+    deactivateVideo,
 }: Props): JSX.Element => {
     /**
      * useRef for player and progressEvents
@@ -348,6 +350,7 @@ export const YoutubeAtomPlayer = ({
                                     player.current?.pauseVideo();
                                 }
                             });
+                            deactivateVideo();
                         }
                     }
                 };

--- a/src/YoutubeAtomSticky.tsx
+++ b/src/YoutubeAtomSticky.tsx
@@ -112,7 +112,7 @@ type Props = {
     eventEmitters: ((event: VideoEventKey) => void)[];
     shouldStick?: boolean;
     setPauseVideo: () => void;
-    hasStarted: boolean;
+    isActive: boolean;
     isMainMedia?: boolean;
     children: JSX.Element;
 };
@@ -124,7 +124,7 @@ export const YoutubeAtomSticky = ({
     eventEmitters,
     shouldStick,
     setPauseVideo,
-    hasStarted,
+    isActive,
     isMainMedia,
     children,
 }: Props): JSX.Element => {
@@ -190,8 +190,8 @@ export const YoutubeAtomSticky = ({
      * useEffect for the sticky state
      */
     useEffect(() => {
-        if (shouldStick) setIsSticky(hasStarted && !isIntersecting);
-    }, [isIntersecting, hasStarted, shouldStick]);
+        if (shouldStick) setIsSticky(isActive && !isIntersecting);
+    }, [isIntersecting, isActive, shouldStick]);
 
     /**
      * useEffect for the stick events

--- a/src/YoutubeAtomSticky.tsx
+++ b/src/YoutubeAtomSticky.tsx
@@ -108,6 +108,7 @@ const stickyContainerStyles = (isMainMedia?: boolean) => {
 };
 
 type Props = {
+    uniqueId: string;
     videoId: string;
     eventEmitters: ((event: VideoEventKey) => void)[];
     shouldStick?: boolean;
@@ -122,6 +123,7 @@ type Props = {
 const isMobile = detectMobile({ tablet: true });
 
 export const YoutubeAtomSticky = ({
+    uniqueId,
     videoId,
     eventEmitters,
     shouldStick,
@@ -234,7 +236,12 @@ export const YoutubeAtomSticky = ({
     const showCloseButton = !showOverlay && isMobile;
 
     return (
-        <div ref={setRef} css={isSticky && stickyContainerStyles(isMainMedia)}>
+        <div
+            ref={setRef}
+            css={isSticky && stickyContainerStyles(isMainMedia)}
+            data-cy={`atom-sticky-${uniqueId}`}
+            data-is-sticky={isSticky}
+        >
             <div css={isSticky && stickyStyles(showCloseButton)}>
                 {children}
                 {isSticky && (

--- a/src/YoutubeAtomSticky.tsx
+++ b/src/YoutubeAtomSticky.tsx
@@ -115,6 +115,8 @@ type Props = {
     isActive: boolean;
     isMainMedia?: boolean;
     children: JSX.Element;
+    isClosed: boolean;
+    setIsClosed: (state: boolean) => void;
 };
 
 const isMobile = detectMobile({ tablet: true });
@@ -127,6 +129,8 @@ export const YoutubeAtomSticky = ({
     isActive,
     isMainMedia,
     children,
+    isClosed,
+    setIsClosed,
 }: Props): JSX.Element => {
     const [isSticky, setIsSticky] = useState<boolean>(false);
     const [stickEventSent, setStickEventSent] = useState<boolean>(false);
@@ -148,6 +152,8 @@ export const YoutubeAtomSticky = ({
         setStickEventSent(false);
         // pause the video
         setPauseVideo();
+        // set isClosed so that player won't restick
+        setIsClosed(true);
 
         // log a 'close' event
         log('dotcom', {
@@ -190,8 +196,8 @@ export const YoutubeAtomSticky = ({
      * useEffect for the sticky state
      */
     useEffect(() => {
-        if (shouldStick) setIsSticky(isActive && !isIntersecting);
-    }, [isIntersecting, isActive, shouldStick]);
+        if (shouldStick) setIsSticky(isActive && !isIntersecting && !isClosed);
+    }, [isIntersecting, isActive, shouldStick, isClosed]);
 
     /**
      * useEffect for the stick events

--- a/src/YoutubeAtomSticky.tsx
+++ b/src/YoutubeAtomSticky.tsx
@@ -112,7 +112,7 @@ type Props = {
     eventEmitters: ((event: VideoEventKey) => void)[];
     shouldStick?: boolean;
     onStopVideo: () => void;
-    isPlaying: boolean;
+    hasStarted: boolean;
     isMainMedia?: boolean;
     children: JSX.Element;
 };
@@ -124,7 +124,7 @@ export const YoutubeAtomSticky = ({
     eventEmitters,
     shouldStick,
     onStopVideo,
-    isPlaying,
+    hasStarted,
     isMainMedia,
     children,
 }: Props): JSX.Element => {
@@ -190,8 +190,8 @@ export const YoutubeAtomSticky = ({
      * useEffect for the sticky state
      */
     useEffect(() => {
-        if (shouldStick) setIsSticky(isPlaying && !isIntersecting);
-    }, [isIntersecting, isPlaying, shouldStick]);
+        if (shouldStick) setIsSticky(hasStarted && !isIntersecting);
+    }, [isIntersecting, hasStarted, shouldStick]);
 
     /**
      * useEffect for the stick events

--- a/src/YoutubeAtomSticky.tsx
+++ b/src/YoutubeAtomSticky.tsx
@@ -111,7 +111,7 @@ type Props = {
     videoId: string;
     eventEmitters: ((event: VideoEventKey) => void)[];
     shouldStick?: boolean;
-    onStopVideo: () => void;
+    setPauseVideo: () => void;
     hasStarted: boolean;
     isMainMedia?: boolean;
     children: JSX.Element;
@@ -123,7 +123,7 @@ export const YoutubeAtomSticky = ({
     videoId,
     eventEmitters,
     shouldStick,
-    onStopVideo,
+    setPauseVideo,
     hasStarted,
     isMainMedia,
     children,
@@ -146,8 +146,8 @@ export const YoutubeAtomSticky = ({
         setIsSticky(false);
         // reset the sticky event sender
         setStickEventSent(false);
-        // stop the video
-        onStopVideo();
+        // pause the video
+        setPauseVideo();
 
         // log a 'close' event
         log('dotcom', {

--- a/src/YoutubeAtomSticky.tsx
+++ b/src/YoutubeAtomSticky.tsx
@@ -190,7 +190,6 @@ export const YoutubeAtomSticky = ({
      */
     useEffect(() => {
         window.addEventListener('keydown', handleKeydown);
-
         return () => window.removeEventListener('keydown', handleKeydown);
     }, []);
 
@@ -239,7 +238,7 @@ export const YoutubeAtomSticky = ({
         <div
             ref={setRef}
             css={isSticky && stickyContainerStyles(isMainMedia)}
-            data-cy={`atom-sticky-${uniqueId}`}
+            data-cy={`youtube-sticky-${uniqueId}`}
             data-is-sticky={isSticky}
         >
             <div css={isSticky && stickyStyles(showCloseButton)}>

--- a/src/YoutubeAtomSticky.tsx
+++ b/src/YoutubeAtomSticky.tsx
@@ -249,7 +249,11 @@ export const YoutubeAtomSticky = ({
                             css={hoverAreaStyles(showOverlay)}
                             onClick={() => setShowOverlay(false)}
                         />
-                        <button css={buttonStyles} onClick={handleCloseClick}>
+                        <button
+                            css={buttonStyles}
+                            onClick={handleCloseClick}
+                            data-cy={`youtube-sticky-close-${uniqueId}`}
+                        >
                             <SvgCross size="medium" />
                         </button>
                     </>


### PR DESCRIPTION
Co-authored-by: Zeke Hunter-Green <zeke.huntergreen@guardian.co.uk>

## What does this change?

- Update YoutubeAtom behaviour to pause rather than stop when:
  - another video is played on the same page
    (introduced: #401)
  - a sticky video is closed
- Rename `isPlaying` to `isActive` to more closely reflect that the video has started but may be paused. This also helps avoid multiple videos sticking - only an active video can be sticky
- Introduce new state hook `isClosed` to stop a closed video from re-sticking

## Why?
We have done this for a couple of reasons:

- pausing is better aligned to how IMA ads integration (#447) expects the player to behave. Stopping a leads to two state changes, unstarted, and cued which triggers an IMA ad playing.
- better user experience - users won't lose their place in a video when closing it or starting another video.

| | Before      | After      |
|-|------------|------------|
| Close Sticky Video | ![main close sticky video](https://user-images.githubusercontent.com/17057932/187250873-1ba76d19-beb8-48bb-937c-0c4673c0fc9e.gif) | ![pr close sticky video](https://user-images.githubusercontent.com/17057932/187251235-34f5eac0-85a3-4e37-86a9-82dd28e06072.gif) |
| Start second video | ![main multiple videos](https://user-images.githubusercontent.com/17057932/187252083-18dd929c-8eec-41c3-9154-e639029d4401.gif) |  ![pr multiple videos](https://user-images.githubusercontent.com/17057932/187252101-181199db-21cb-4e2b-a03c-73554df0f3f2.gif) |

## How to test

Run storybook with the `Sticky` and `Multiple sticky videos` stories to confirm that 
- when a sticky video is closed, it pauses rather than stops
- a closed video won't stick unless it's played again (becoming active)
- a first video pauses, and if it's sticky, unsticks when a second video is played
