### PR TITLE
Quiz Accessibility - Add image alts, fix legends

### DIFF
--- a/.changeset/shaggy-forks-type.md
+++ b/.changeset/shaggy-forks-type.md
@@ -1,0 +1,5 @@
+---
+'@guardian/atoms-rendering': minor
+---
+
+Fixes an accessibility problem with the legend element & Adds support for image alts on quizes

--- a/src/KnowledgeQuiz.tsx
+++ b/src/KnowledgeQuiz.tsx
@@ -35,6 +35,7 @@ type QuestionType = {
     text: string;
     answers: AnswerType[];
     imageUrl?: string;
+    imageAlt?: string;
 };
 
 type QuizAtomType = {
@@ -92,6 +93,7 @@ export const KnowledgeQuizAtom = ({
                     number={idx + 1}
                     text={question.text}
                     imageUrl={question.imageUrl}
+                    imageAlt={question.imageAlt}
                     answers={question.answers}
                     quizSelection={quizSelection}
                     setQuizSelection={setQuizSelection}
@@ -115,6 +117,7 @@ export const Question = ({
     id,
     text,
     imageUrl,
+    imageAlt,
     answers,
     number,
     quizSelection,
@@ -153,28 +156,27 @@ export const Question = ({
             `}
         >
             <fieldset css={fieldsetStyle}>
-                <div>
-                    <legend
+                <legend
+                    css={css`
+                        margin-bottom: 12px;
+                    `}
+                >
+                    <span
                         css={css`
-                            margin-bottom: 12px;
+                            padding-right: 12px;
                         `}
                     >
-                        <span
-                            css={css`
-                                padding-right: 12px;
-                            `}
-                        >
-                            {`${number}.`}
-                        </span>
-                        {text}
-                    </legend>
-                </div>
+                        {`${number}.`}
+                    </span>
+                    {text}
+                </legend>
                 {imageUrl && (
                     <img
                         css={css`
                             width: 100%;
                         `}
                         src={imageUrl}
+                        alt={imageAlt || ''}
                     />
                 )}
                 <Answers

--- a/src/PersonalityQuiz.tsx
+++ b/src/PersonalityQuiz.tsx
@@ -40,6 +40,7 @@ type QuestionType = {
     text: string;
     answers: AnswerType[];
     imageUrl?: string;
+    imageAlt?: string;
 };
 
 type QuizAtomType = {
@@ -182,6 +183,7 @@ export const PersonalityQuizAtom = ({
                     questionNumber={idx + 1}
                     text={question.text}
                     imageUrl={question.imageUrl}
+                    imageAlt={question.imageAlt}
                     answers={question.answers}
                     updateSelectedAnswer={(selectedAnswerId: string) => {
                         setHasMissingAnswers(false);
@@ -260,6 +262,7 @@ type PersonalityQuizAnswersProps = {
     questionNumber: number;
     text: string;
     imageUrl?: string;
+    imageAlt?: string;
     answers: AnswerType[];
     updateSelectedAnswer: (selectedAnswerId: string) => void;
     globallySelectedAnswer?: string;
@@ -272,6 +275,7 @@ const PersonalityQuizAnswers = ({
     questionNumber,
     text,
     imageUrl,
+    imageAlt,
     answers,
     updateSelectedAnswer,
     globallySelectedAnswer,
@@ -294,28 +298,27 @@ const PersonalityQuizAnswers = ({
 
     return (
         <fieldset css={answersWrapperStyle(theme)}>
-            <div>
-                <legend
+            <legend
+                css={css`
+                    margin-bottom: 12px;
+                `}
+            >
+                <span
                     css={css`
-                        margin-bottom: 12px;
+                        padding-right: 12px;
                     `}
                 >
-                    <span
-                        css={css`
-                            padding-right: 12px;
-                        `}
-                    >
-                        {questionNumber + '.'}
-                    </span>
-                    {text}
-                </legend>
-            </div>
+                    {questionNumber + '.'}
+                </span>
+                {text}
+            </legend>
             {imageUrl && (
                 <img
                     css={css`
                         width: 100%;
                     `}
                     src={imageUrl}
+                    alt={imageAlt || ''}
                 />
             )}
             <AnswersGroup

--- a/src/fixtures/knowledgeQuizAtom.ts
+++ b/src/fixtures/knowledgeQuizAtom.ts
@@ -96,6 +96,7 @@ export const exampleKnowledgeQuestions = [
         ],
         imageUrl:
             'https://i.guim.co.uk/img/media/9bd896505173dcf4adadd02e5f40a03414c50bdc/172_201_2329_1397/master/2329.jpg?width=620&quality=85&auto=format&fit=max&s=133b7c6ce78a0780e99e605bb3ae7479',
+        imageAlt: 'A group of players line up on the field',
     },
 ];
 
@@ -447,6 +448,8 @@ export const natureQuestions = [
         ],
         imageUrl:
             'https://i.guim.co.uk/img/media/cf44ae3573ee2b617f76021c6599f49316837e09/56_581_4045_2427/master/4045.jpg?width=620&quality=85&auto=format&fit=max&s=afb7e45cc2a3873745cb5bcb620d8291',
+        imageAlt:
+            'Brown winged butterfly with white spots, some of which have black spots with white eyes within them',
     },
     {
         id: '4339cc24-d597-43d0-9efd-2dd9d8f4982f',

--- a/src/fixtures/personalityQuizAtom.ts
+++ b/src/fixtures/personalityQuizAtom.ts
@@ -117,6 +117,8 @@ export const examplePersonalityQuestions = [
         ],
         imageUrl:
             'https://i.guim.co.uk/img/media/816db2120eb8020529b5882c19be8432acb64741/0_0_1920_1152/master/1920.jpg?width=620&quality=85&auto=format&fit=max&s=0226a9202b9014a60f977f42b319113e',
+        imageAlt:
+            'The sun coming over the horizon, with the sky & clouds lit up red.',
     },
 ];
 


### PR DESCRIPTION
## What does this change?

This PR

- Adds support for passing image alts to quiz questions
- Fixes accessibility issue where the legend was not detected, due to it being wrapped in a `<div>`

Can be tested once live with: https://wave.webaim.org/report#/https://www.theguardian.com/lifeandstyle/2021/sep/09/the-guardian-thursday-quiz-general-knowledge-topical-news-trivia-9-september

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
