### PR TITLE
Add IMA ad label

### DIFF
--- a/.changeset/green-cooks-check.md
+++ b/.changeset/green-cooks-check.md
@@ -1,0 +1,5 @@
+---
+'@guardian/atoms-rendering': minor
+---
+
+Add ad label to YouTube IMA integration

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -306,6 +306,14 @@ const createInstantiateImaManager =
 
             const onAdsManagerLoaded = () => {
                 adsManager.current = imaManager.current?.getAdsManager();
+                const adsRenderingsettings =
+                    new window.google.ima.AdsRenderingSettings();
+                adsRenderingsettings.uiElements = [
+                    window.google.ima.UiElements.AD_ATTRIBUTION,
+                ];
+                adsManager.current?.updateAdsRenderingSettings(
+                    adsRenderingsettings,
+                );
                 adsManager.current?.addEventListener(
                     window.google.ima.AdEvent.Type.STARTED,
                     () => {


### PR DESCRIPTION
## What does this change?

Enables the IMA YouTube integration UI setting to show an ad label over IMA ads.

## Images

![Screenshot 2022-10-13 at 10 59 27](https://user-images.githubusercontent.com/7014230/195608839-2350dce1-92e9-422f-a4e5-12cc5372d30f.png)
