### PR TITLE
Bump `@guardian/libs@^7.1.0`

### DIFF
--- a/.changeset/perfect-bears-worry.md
+++ b/.changeset/perfect-bears-worry.md
@@ -1,0 +1,5 @@
+---
+'@guardian/atoms-rendering': patch
+---
+
+Bump `@guardian/libs@^7.1.0`

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "@guardian/consent-management-platform": "^10",
         "@guardian/eslint-plugin-source-foundations": "^4.0.2",
         "@guardian/eslint-plugin-source-react-components": "^4.1.0",
-        "@guardian/libs": "^5.1.0",
+        "@guardian/libs": "^7.1.0",
         "@guardian/source-foundations": "^4.0.2",
         "@guardian/source-react-components": "^4.0.1",
         "@storybook/addon-docs": "^6.1.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1714,10 +1714,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-3.3.0.tgz#fa98c7b8216ab35b8cf3087cd9ba336958fac99a"
   integrity sha512-XB9o8qtDOg+KlPh1sjEr4u+Ai3RFTRr2riZ/HJpdlh8Cu4ZpYjCSGUZXSGkxp1CwFWT9sduANnsWSqZ97iBloQ==
 
-"@guardian/libs@^5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-5.1.0.tgz#5f7a228d8382e07809e09aeffed6d472558ed41d"
-  integrity sha512-AKVh+CraVAR49y60IX7UYrIMlfhS/zhN1f31FqJ/nHtGv92XFzCoijknkl+pFQUtuZvD2zYCygpqLGCWPVDk/Q==
+"@guardian/libs@^7.1.0":
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-7.1.4.tgz#f5de14f52a32cb677361d49157c94eb046a2b9a8"
+  integrity sha512-r2AJk+4EakNLCLXHhUEqdYSjFhuq19k7tsQO5+53YZc6x6ADEXFNRVE/7EzbODgu5pVwk5SQ/rMuWsE7+5qdVQ==
 
 "@guardian/source-foundations@^4.0.2":
   version "4.0.2"


### PR DESCRIPTION
## What does this change?

Bump `@guardian/libs@^7.1.0` to align types with DCR.

In DCR prop types have diverged since https://github.com/guardian/dotcom-rendering/pull/5750 and tsc fails when bumping atoms-rendering.

