### PR TITLE
Bump `@guardian/libs@^9.0.1`

### DIFF
--- a/.changeset/healthy-horses-talk.md
+++ b/.changeset/healthy-horses-talk.md
@@ -1,0 +1,5 @@
+---
+'@guardian/atoms-rendering': patch
+---
+
+Bump `@guardian/libs@^9.0.1`

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "@guardian/consent-management-platform": "^10",
         "@guardian/eslint-plugin-source-foundations": "^4.0.2",
         "@guardian/eslint-plugin-source-react-components": "^4.1.0",
-        "@guardian/libs": "^7.1.0",
+        "@guardian/libs": "^9.0.1",
         "@guardian/source-foundations": "^4.0.2",
         "@guardian/source-react-components": "^4.0.1",
         "@storybook/addon-docs": "^6.1.11",

--- a/src/lib/pillarPalette.ts
+++ b/src/lib/pillarPalette.ts
@@ -25,4 +25,5 @@ export const pillarPalette: Record<ArticleTheme, PillarColours> = {
     [ArticlePillar.Lifestyle]: lifestyle,
     [ArticleSpecial.Labs]: lifestyle,
     [ArticleSpecial.SpecialReport]: news,
+    [ArticleSpecial.SpecialReportAlt]: news,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1714,10 +1714,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-3.3.0.tgz#fa98c7b8216ab35b8cf3087cd9ba336958fac99a"
   integrity sha512-XB9o8qtDOg+KlPh1sjEr4u+Ai3RFTRr2riZ/HJpdlh8Cu4ZpYjCSGUZXSGkxp1CwFWT9sduANnsWSqZ97iBloQ==
 
-"@guardian/libs@^7.1.0":
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-7.1.4.tgz#f5de14f52a32cb677361d49157c94eb046a2b9a8"
-  integrity sha512-r2AJk+4EakNLCLXHhUEqdYSjFhuq19k7tsQO5+53YZc6x6ADEXFNRVE/7EzbODgu5pVwk5SQ/rMuWsE7+5qdVQ==
+"@guardian/libs@^9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@guardian/libs/-/libs-9.0.1.tgz#0cae687b733d8ab34af6482edb5da07e815eb58f"
+  integrity sha512-3nDfG/wRjhAXejQH4MCc0C0fpl5aSDQhuyOYqi5lb+nfrpw5uldH89xVIB/fcIK+OcrrCeCEndbPvpP41298vw==
 
 "@guardian/source-foundations@^4.0.2":
   version "4.0.2"


### PR DESCRIPTION
## What does this change?

Bump `@guardian/libs@^9.0.1` to align format with DCR. 

In DCR we're introducing new `SpecialReportAltTheme` and some stories are failing because of some atoms that do not handle it. See more:
https://github.com/guardian/csnx/pull/132
https://github.com/guardian/dotcom-rendering/pull/6201
https://www.chromatic.com/build?appId=5dfcbf3012392c0020e7140b&number=16243

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
