### PR TITLE
fix: YouTube IMA ad label

### DIFF
--- a/.changeset/weak-bears-shave.md
+++ b/.changeset/weak-bears-shave.md
@@ -1,0 +1,5 @@
+---
+'@guardian/atoms-rendering': patch
+---
+
+Fix YouTube IMA ad label

--- a/src/YoutubeAtom.stories.tsx
+++ b/src/YoutubeAtom.stories.tsx
@@ -238,6 +238,7 @@ export const GiveConsent = (): JSX.Element => {
 export const Sticky = (): JSX.Element => {
     return (
         <div>
+            <div style={{ fontSize: '36px' }}>⬇️</div>
             <div style={{ height: '1000px' }}></div>
             <YoutubeAtom
                 elementId="xyz"
@@ -265,6 +266,7 @@ export const Sticky = (): JSX.Element => {
 export const StickyMainMedia = (): JSX.Element => {
     return (
         <div>
+            <div style={{ fontSize: '36px' }}>⬇️</div>
             <div style={{ height: '1000px' }}></div>
             <YoutubeAtom
                 elementId="xyz"

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -23,7 +23,10 @@ declare class ImaManager {
         player: YT.Player,
         id: string,
         adContainerId: string,
-        makeAdsRequestCallback: (adsRequest: { adTagUrl: string }) => void,
+        makeAdsRequestCallback: (
+            adsRequest: { adTagUrl: string },
+            adsRenderingSettings: google.ima.AdsRenderingSettings,
+        ) => void,
     );
     getAdsLoader: () => google.ima.AdsLoader;
     getAdsManager: () => google.ima.AdsManager;
@@ -299,8 +302,14 @@ const createInstantiateImaManager =
                 ? adTargeting.customParams
                 : {};
 
-        const makeAdsRequestCallback = (adsRequest: { adTagUrl: string }) => {
+        const makeAdsRequestCallback = (
+            adsRequest: { adTagUrl: string },
+            adsRenderingSettings: google.ima.AdsRenderingSettings,
+        ) => {
             adsRequest.adTagUrl = buildImaAdTagUrl(adUnit, customParams);
+            adsRenderingSettings.uiElements = [
+                window.google.ima.UiElements.AD_ATTRIBUTION,
+            ];
         };
 
         if (typeof window.YT.ImaManager !== 'undefined') {
@@ -314,14 +323,6 @@ const createInstantiateImaManager =
 
             const onAdsManagerLoaded = () => {
                 adsManager.current = imaManager.current?.getAdsManager();
-                const adsRenderingsettings =
-                    new window.google.ima.AdsRenderingSettings();
-                adsRenderingsettings.uiElements = [
-                    window.google.ima.UiElements.AD_ATTRIBUTION,
-                ];
-                adsManager.current?.updateAdsRenderingSettings(
-                    adsRenderingsettings,
-                );
                 adsManager.current?.addEventListener(
                     window.google.ima.AdEvent.Type.STARTED,
                     () => {

--- a/src/YoutubeAtomWithImaAd.stories.tsx
+++ b/src/YoutubeAtomWithImaAd.stories.tsx
@@ -274,6 +274,7 @@ export const GiveConsent = (): JSX.Element => {
 export const Sticky = (): JSX.Element => {
     return (
         <div>
+            <div style={{ fontSize: '36px' }}>⬇️</div>
             <div style={{ height: '1000px' }}></div>
             <YoutubeAtom
                 elementId="xyz"
@@ -302,6 +303,7 @@ export const Sticky = (): JSX.Element => {
 export const StickyMainMedia = (): JSX.Element => {
     return (
         <div>
+            <div style={{ fontSize: '36px' }}>⬇️</div>
             <div style={{ height: '1000px' }}></div>
             <YoutubeAtom
                 elementId="xyz"


### PR DESCRIPTION
## What does this change?

Changes the method of displaying the YouTube IMA ad attribution label following a bugfix from Google.

Previously the ad label would not show when the player has an overlay - which is true for the vast majority of our videos.

## How to test

The ad label appears for all instance of IMA enabled players.

## Images

Before:

<img width="830" alt="Screenshot 2022-11-03 at 12 44 14" src="https://user-images.githubusercontent.com/7014230/199723618-292c34a3-d743-4a98-82cf-cd79b15f3be5.png">

After:

<img width="841" alt="Screenshot 2022-11-03 at 12 43 31" src="https://user-images.githubusercontent.com/7014230/199723876-4d945526-db1c-41f6-a01d-8175856fd144.png">
