### PR TITLE
feat: Full targeting for YouTube IMA integration

### DIFF
--- a/.changeset/tricky-carpets-double.md
+++ b/.changeset/tricky-carpets-double.md
@@ -1,0 +1,5 @@
+---
+'@guardian/atoms-rendering': minor
+---
+
+Full targeting for YouTube IMA integration

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "@changesets/cli": "^2.21.1",
         "@emotion/eslint-plugin": "^11.7.0",
         "@emotion/react": "^11.1.5",
-        "@guardian/commercial-core": "^4.21.0",
+        "@guardian/commercial-core": "^4.22.0",
         "@guardian/consent-management-platform": "^10",
         "@guardian/eslint-plugin-source-foundations": "^4.0.2",
         "@guardian/eslint-plugin-source-react-components": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -111,12 +111,12 @@
     },
     "peerDependencies": {
         "@emotion/react": "^11.1.5",
-        "@guardian/consent-management-platform": "^8",
+        "@guardian/consent-management-platform": "^10",
         "@guardian/source-foundations": "^4.0.2",
         "@guardian/source-react-components": "^4.0.1",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
-        "typescript": "^4.1.3",
+        "typescript": "^4.8.4",
         "web-vitals": "^2.1.4"
     },
     "jest": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "@changesets/cli": "^2.21.1",
         "@emotion/eslint-plugin": "^11.7.0",
         "@emotion/react": "^11.1.5",
-        "@guardian/commercial-core": "^4.22.0",
+        "@guardian/commercial-core": "^4.23.0",
         "@guardian/consent-management-platform": "^10",
         "@guardian/eslint-plugin-source-foundations": "^4.0.2",
         "@guardian/eslint-plugin-source-react-components": "^4.1.0",

--- a/src/YoutubeAtomPlayer.tsx
+++ b/src/YoutubeAtomPlayer.tsx
@@ -290,6 +290,7 @@ const createInstantiateImaManager =
         id: string,
         adContainerId: string,
         adTargeting: AdTargeting | undefined,
+        consentState: ConsentState,
         imaManager: React.MutableRefObject<ImaManager | undefined>,
         adsManager: React.MutableRefObject<google.ima.AdsManager | undefined>,
     ) =>
@@ -306,7 +307,11 @@ const createInstantiateImaManager =
             adsRequest: { adTagUrl: string },
             adsRenderingSettings: google.ima.AdsRenderingSettings,
         ) => {
-            adsRequest.adTagUrl = buildImaAdTagUrl(adUnit, customParams);
+            adsRequest.adTagUrl = buildImaAdTagUrl(
+                adUnit,
+                customParams,
+                consentState,
+            );
             adsRenderingSettings.uiElements = [
                 window.google.ima.UiElements.AD_ATTRIBUTION,
             ];
@@ -428,6 +433,7 @@ export const YoutubeAtomPlayer = ({
                           id,
                           imaAdContainerId,
                           adTargeting,
+                          consentState,
                           imaManager,
                           adsManager,
                       )

--- a/src/YoutubeAtomWithImaAd.stories.tsx
+++ b/src/YoutubeAtomWithImaAd.stories.tsx
@@ -12,7 +12,9 @@ export default {
 const containerStyle = { width: '800px', margin: '24px' };
 const containerStyleSmall = { width: '400px', margin: '24px' };
 const adTargeting = {
-    customParams: {},
+    customParams: {
+        at: 'fixed-puppies',
+    },
     adUnit: '/59666047/theguardian.com/news/article/ng',
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1477,10 +1477,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@guardian/commercial-core@^4.21.0":
-  version "4.21.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.21.0.tgz#d6ad678a563bd82c3ed738bc4f77a0c7494a5120"
-  integrity sha512-OpME2iB6Dosvdu7MF8npzgIeRFOPWwdeSVNaUI3aB1wqU+FQh47cozGk1BASgCXlsUwhhGvQbx5vTBkDiptsgQ==
+"@guardian/commercial-core@^4.22.0":
+  version "4.22.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.22.0.tgz#7e8f0217a129abe7abefc0223300ef48e24514c5"
+  integrity sha512-Ljm6+VMZ9l0kMgyRWE2+9XLh/udSCdRx/0VR40mAJFxf7iaEIUpiAtk7WCKSn6lJ2dV95dJT3/YDo/a3wg9Y8w==
 
 "@guardian/consent-management-platform@^10":
   version "10.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1477,10 +1477,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@guardian/commercial-core@^4.22.0":
-  version "4.22.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.22.0.tgz#7e8f0217a129abe7abefc0223300ef48e24514c5"
-  integrity sha512-Ljm6+VMZ9l0kMgyRWE2+9XLh/udSCdRx/0VR40mAJFxf7iaEIUpiAtk7WCKSn6lJ2dV95dJT3/YDo/a3wg9Y8w==
+"@guardian/commercial-core@^4.23.0":
+  version "4.23.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.23.0.tgz#61e37be8be66fdb98bce2efb175bcd8e93df2883"
+  integrity sha512-NGbB2gSVhaMZ6SvEGKXVvLK8OuAjl+azhTMSfiVmlrnIoye3KP1KK5ziB5Iu5dGPnDS4W8nYD3eR+ib7WcCBNg==
 
 "@guardian/consent-management-platform@^10":
   version "10.8.0"


### PR DESCRIPTION
## What does this change?

Bumps `commercial-core` to bring in [full page targeting](https://github.com/guardian/commercial-core/blob/d9de9eb0c8605516f02ed42a63a330f5fb02f719/src/targeting/build-page-targeting.ts) (via https://github.com/guardian/commercial-core/pull/709) for the YouTube IMA integration.

This will allow ad ops to target YouTube IMA ads using all the regular targeting we use in Google Ad Manager.

## How to test

When running with DCR the IMA request to GAM should have full page targeting on the `cust_params` parameter.

- open developer tools network panel
- ensure you are in the IMA ab test
- click play on a YouTube video
- inspect requests to https://pubads.g.doubleclick.net/gampad/ads?...
- verify `cust_params` contains page targeting with https://guardian.github.io/commercial-request-parser/

