### PR TITLE
feat: Bump `commercial-core` to `4.24.0`

### DIFF
--- a/.changeset/big-moose-wash.md
+++ b/.changeset/big-moose-wash.md
@@ -1,0 +1,5 @@
+---
+'@guardian/atoms-rendering': minor
+---
+
+Full targeting for YouTubeAtomPlayer

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "@changesets/cli": "^2.21.1",
         "@emotion/eslint-plugin": "^11.7.0",
         "@emotion/react": "^11.1.5",
-        "@guardian/commercial-core": "^4.23.0",
+        "@guardian/commercial-core": "^4.24.0",
         "@guardian/consent-management-platform": "^10",
         "@guardian/eslint-plugin-source-foundations": "^4.0.2",
         "@guardian/eslint-plugin-source-react-components": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1477,10 +1477,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@guardian/commercial-core@^4.23.0":
-  version "4.23.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.23.0.tgz#61e37be8be66fdb98bce2efb175bcd8e93df2883"
-  integrity sha512-NGbB2gSVhaMZ6SvEGKXVvLK8OuAjl+azhTMSfiVmlrnIoye3KP1KK5ziB5Iu5dGPnDS4W8nYD3eR+ib7WcCBNg==
+"@guardian/commercial-core@^4.24.0":
+  version "4.24.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.24.0.tgz#4812d2a97f8b888092a4170624a0871742d83128"
+  integrity sha512-6ql4W6y0bx0GehSn7jNEkcn8DAoq3b/R9sfOCtbI952rouSaoKtIZcxKPK9PA9vSkWqkXF3hm9r/Ci2AKo+7gA==
 
 "@guardian/consent-management-platform@^10":
   version "10.8.0"


### PR DESCRIPTION
## What does this change?

Bumps commercial-core to `4.24.0`. 

This improves ad targeting in `YoutubeAtomPlayer` via its call to `buildAdsConfigWithConsent` which was updated in commercial-core in [this PR](https://github.com/guardian/commercial-core/pull/708). This brings targeting in line with regular GAM targeting, which we already use for videos rendered by frontend.

## How to test

- publish this version of `atoms-rendering` and pull it into `dotcom-rendering`
- deploy `dotcom-rendering` to CODE
- load these two articles: [Article 1](https://m.code.dev-theguardian.com/uk-news/video/2022/oct/27/suella-braverman-deserves-second-chance-nadhim-zahawi-video) (rendered by frontend) & [Article 2](https://m.code.dev-theguardian.com/us-news/2022/nov/16/us-midterms-2022-republicans-win-control-house-representatives-congress-midterm-election-results) (rendered by DCR - and therefore affected by this change)
- inspect network requests and filter by `youtube.com/embed`
- press play on videos in each article
- use the [request differ tool](https://guardian.github.io/commercial-request-parser/) to parse and compare the URLs of the requests to youtube
- note they should now contain the same targeting keys. For example, `ab`, `bp`, `fr`, `rp` are included in Article 2 when they weren't previously (check against [prod](https://www.theguardian.com/us-news/2022/nov/16/us-midterms-2022-republicans-win-control-house-representatives-congress-midterm-election-results))

## Screenshot

Using the [request differ](https://guardian.github.io/commercial-request-parser/) to compare requests from production (left) vs local (right) for [Article 2](https://www.theguardian.com/us-news/2022/nov/16/us-midterms-2022-republicans-win-control-house-representatives-congress-midterm-election-results)

![Screenshot 2022-11-17 at 16 07 07](https://user-images.githubusercontent.com/7423751/202497370-2102117d-1fb6-4772-bf6c-0fd4a25e768c.png)
