### PR TITLE
feat: YouTube player is passed client side participations for targeting

### DIFF
--- a/.changeset/four-bottles-flow.md
+++ b/.changeset/four-bottles-flow.md
@@ -1,0 +1,5 @@
+---
+'@guardian/atoms-rendering': minor
+---
+
+YouTube player is passed client side participations for targeting

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
         "@changesets/cli": "^2.21.1",
         "@emotion/eslint-plugin": "^11.7.0",
         "@emotion/react": "^11.1.5",
+        "@guardian/ab-core": "^2.0.0",
         "@guardian/commercial-core": "^4.24.0",
         "@guardian/consent-management-platform": "^10",
         "@guardian/eslint-plugin-source-foundations": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "@emotion/eslint-plugin": "^11.7.0",
         "@emotion/react": "^11.1.5",
         "@guardian/ab-core": "^2.0.0",
-        "@guardian/commercial-core": "^4.24.0",
+        "@guardian/commercial-core": "^4.25.0",
         "@guardian/consent-management-platform": "^10",
         "@guardian/eslint-plugin-source-foundations": "^4.0.2",
         "@guardian/eslint-plugin-source-react-components": "^4.1.0",

--- a/src/YoutubeAtom.stories.tsx
+++ b/src/YoutubeAtom.stories.tsx
@@ -29,6 +29,7 @@ export const NoConsent = (): JSX.Element => {
                 shouldStick={false}
                 isMainMedia={false}
                 imaEnabled={false}
+                abTestParticipations={{}}
             />
         </div>
     );
@@ -54,6 +55,7 @@ export const NoOverlay = (): JSX.Element => {
                 isMainMedia={false}
                 title="Rayshard Brooks: US justice system treats us like 'animals'"
                 imaEnabled={false}
+                abTestParticipations={{}}
             />
         </div>
     );
@@ -87,6 +89,7 @@ export const WithOverrideImage = (): JSX.Element => {
                 isMainMedia={false}
                 title="How to stop the spread of coronavirus"
                 imaEnabled={false}
+                abTestParticipations={{}}
             />
         </div>
     );
@@ -134,6 +137,7 @@ export const WithPosterImage = (): JSX.Element => {
                 isMainMedia={false}
                 title="How Donald Trump’s broken promises failed Ohio | Anywhere but Washington"
                 imaEnabled={false}
+                abTestParticipations={{}}
             />
         </div>
     );
@@ -191,6 +195,7 @@ export const WithOverlayAndPosterImage = (): JSX.Element => {
                 isMainMedia={false}
                 title="How Donald Trump’s broken promises failed Ohio"
                 imaEnabled={false}
+                abTestParticipations={{}}
             />
         </div>
     );
@@ -229,6 +234,7 @@ export const GiveConsent = (): JSX.Element => {
                     isMainMedia={false}
                     title="How to stop the spread of coronavirus"
                     imaEnabled={false}
+                    abTestParticipations={{}}
                 />
             </div>
         </>
@@ -257,6 +263,7 @@ export const Sticky = (): JSX.Element => {
                 isMainMedia={true}
                 title="Rayshard Brooks: US justice system treats us like 'animals'"
                 imaEnabled={false}
+                abTestParticipations={{}}
             />
             <div style={{ height: '1000px' }}></div>
         </div>
@@ -285,6 +292,7 @@ export const StickyMainMedia = (): JSX.Element => {
                 isMainMedia={true}
                 title="Rayshard Brooks: US justice system treats us like 'animals'"
                 imaEnabled={false}
+                abTestParticipations={{}}
             />
             <div style={{ height: '1000px' }}></div>
         </div>
@@ -309,6 +317,7 @@ export const DuplicateVideos = (): JSX.Element => {
                 width={800}
                 shouldStick={true}
                 imaEnabled={false}
+                abTestParticipations={{}}
             />
             <br />
             <YoutubeAtom
@@ -326,6 +335,7 @@ export const DuplicateVideos = (): JSX.Element => {
                 width={800}
                 shouldStick={true}
                 imaEnabled={false}
+                abTestParticipations={{}}
             />
         </div>
     );
@@ -351,6 +361,7 @@ export const MultipleStickyVideos = (): JSX.Element => {
                 isMainMedia={true}
                 title="Rayshard Brooks: US justice system treats us like 'animals'"
                 imaEnabled={false}
+                abTestParticipations={{}}
             />
             <YoutubeAtom
                 elementId="xyz-2"
@@ -369,6 +380,7 @@ export const MultipleStickyVideos = (): JSX.Element => {
                 isMainMedia={true}
                 title="Rayshard Brooks: US justice system treats us like 'animals'"
                 imaEnabled={false}
+                abTestParticipations={{}}
             />
             <YoutubeAtom
                 elementId="xyu"
@@ -387,6 +399,7 @@ export const MultipleStickyVideos = (): JSX.Element => {
                 isMainMedia={true}
                 title="Rayshard Brooks: US justice system treats us like 'animals'"
                 imaEnabled={false}
+                abTestParticipations={{}}
             />
         </div>
     );

--- a/src/YoutubeAtom.stories.tsx
+++ b/src/YoutubeAtom.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
-
 import { YoutubeAtom } from './YoutubeAtom';
 import { ArticlePillar } from '@guardian/libs';
+import { consentStateCanTarget } from './fixtures/consentStateCanTarget';
 
 export default {
     title: 'YoutubeAtom',
@@ -46,7 +46,7 @@ export const NoOverlay = (): JSX.Element => {
                 eventEmitters={[
                     (e) => console.log(`analytics event ${e} called`),
                 ]}
-                consentState={{}}
+                consentState={consentStateCanTarget}
                 duration={252}
                 pillar={ArticlePillar.Culture}
                 height={450}
@@ -73,7 +73,7 @@ export const WithOverrideImage = (): JSX.Element => {
                     (e) => console.log(`analytics event ${e} called`),
                 ]}
                 duration={252}
-                consentState={{}}
+                consentState={consentStateCanTarget}
                 pillar={ArticlePillar.News}
                 overrideImage={[
                     {
@@ -108,7 +108,7 @@ export const WithPosterImage = (): JSX.Element => {
                 ]}
                 pillar={ArticlePillar.Sport}
                 duration={252}
-                consentState={{}}
+                consentState={consentStateCanTarget}
                 posterImage={[
                     {
                         srcSet: [
@@ -166,7 +166,7 @@ export const WithOverlayAndPosterImage = (): JSX.Element => {
                         ],
                     },
                 ]}
-                consentState={{}}
+                consentState={consentStateCanTarget}
                 posterImage={[
                     {
                         srcSet: [
@@ -215,7 +215,7 @@ export const GiveConsent = (): JSX.Element => {
                     eventEmitters={[
                         (e) => console.log(`analytics event ${e} called`),
                     ]}
-                    consentState={consented ? {} : undefined}
+                    consentState={consented ? consentStateCanTarget : undefined}
                     duration={252}
                     pillar={ArticlePillar.News}
                     overrideImage={[
@@ -254,7 +254,7 @@ export const Sticky = (): JSX.Element => {
                 eventEmitters={[
                     (e) => console.log(`analytics event ${e} called`),
                 ]}
-                consentState={{}}
+                consentState={consentStateCanTarget}
                 duration={252}
                 pillar={ArticlePillar.Culture}
                 height={450}
@@ -283,7 +283,7 @@ export const StickyMainMedia = (): JSX.Element => {
                 eventEmitters={[
                     (e) => console.log(`analytics event ${e} called`),
                 ]}
-                consentState={{}}
+                consentState={consentStateCanTarget}
                 duration={252}
                 pillar={ArticlePillar.Culture}
                 height={450}
@@ -310,7 +310,7 @@ export const DuplicateVideos = (): JSX.Element => {
                 eventEmitters={[
                     (e) => console.log(`analytics event ${e} called`),
                 ]}
-                consentState={{}}
+                consentState={consentStateCanTarget}
                 duration={252}
                 pillar={ArticlePillar.Culture}
                 height={450}
@@ -328,7 +328,7 @@ export const DuplicateVideos = (): JSX.Element => {
                 eventEmitters={[
                     (e) => console.log(`analytics event ${e} called`),
                 ]}
-                consentState={{}}
+                consentState={consentStateCanTarget}
                 duration={252}
                 pillar={ArticlePillar.Culture}
                 height={450}
@@ -352,7 +352,7 @@ export const MultipleStickyVideos = (): JSX.Element => {
                 eventEmitters={[
                     (e) => console.log(`analytics event ${e} called`),
                 ]}
-                consentState={{}}
+                consentState={consentStateCanTarget}
                 duration={252}
                 pillar={ArticlePillar.Culture}
                 height={450}
@@ -371,7 +371,7 @@ export const MultipleStickyVideos = (): JSX.Element => {
                 eventEmitters={[
                     (e) => console.log(`analytics event ${e} called`),
                 ]}
-                consentState={{}}
+                consentState={consentStateCanTarget}
                 duration={252}
                 pillar={ArticlePillar.Culture}
                 height={450}
@@ -390,7 +390,7 @@ export const MultipleStickyVideos = (): JSX.Element => {
                 eventEmitters={[
                     (e) => console.log(`analytics event ${e} called`),
                 ]}
-                consentState={{}}
+                consentState={consentStateCanTarget}
                 duration={252}
                 pillar={ArticlePillar.Culture}
                 height={450}

--- a/src/YoutubeAtom.tsx
+++ b/src/YoutubeAtom.tsx
@@ -12,6 +12,7 @@ import type {
 } from './types';
 import type { ArticleTheme } from '@guardian/libs';
 import type { ConsentState } from '@guardian/consent-management-platform/dist/types';
+import type { Participations } from '@guardian/ab-core';
 
 type Props = {
     elementId: string;
@@ -32,6 +33,7 @@ type Props = {
     shouldStick?: boolean;
     isMainMedia?: boolean;
     imaEnabled: boolean;
+    abTestParticipations: Participations;
 };
 
 export const YoutubeAtom = ({
@@ -53,6 +55,7 @@ export const YoutubeAtom = ({
     shouldStick,
     isMainMedia,
     imaEnabled,
+    abTestParticipations,
 }: Props): JSX.Element => {
     const [overlayClicked, setOverlayClicked] = useState<boolean>(false);
     const [playerReady, setPlayerReady] = useState<boolean>(false);
@@ -168,6 +171,7 @@ export const YoutubeAtom = ({
                         deactivateVideo={() => {
                             setIsActive(false);
                         }}
+                        abTestParticipations={abTestParticipations}
                     />
                 )}
                 {showOverlay && (

--- a/src/YoutubeAtomWithImaAd.stories.tsx
+++ b/src/YoutubeAtomWithImaAd.stories.tsx
@@ -37,6 +37,7 @@ export const NoConsent = (): JSX.Element => {
                 shouldStick={false}
                 isMainMedia={false}
                 imaEnabled={true}
+                abTestParticipations={{}}
             />
         </div>
     );
@@ -62,6 +63,7 @@ export const AdFree = (): JSX.Element => {
                 shouldStick={false}
                 isMainMedia={false}
                 imaEnabled={true}
+                abTestParticipations={{}}
             />
         </div>
     );
@@ -88,6 +90,7 @@ export const NoOverlay = (): JSX.Element => {
                 isMainMedia={false}
                 title="Rayshard Brooks: US justice system treats us like 'animals'"
                 imaEnabled={true}
+                abTestParticipations={{}}
             />
         </div>
     );
@@ -122,6 +125,7 @@ export const WithOverrideImage = (): JSX.Element => {
                 isMainMedia={false}
                 title="How to stop the spread of coronavirus"
                 imaEnabled={true}
+                abTestParticipations={{}}
             />
         </div>
     );
@@ -170,6 +174,7 @@ export const WithPosterImage = (): JSX.Element => {
                 isMainMedia={false}
                 title="How Donald Trump’s broken promises failed Ohio | Anywhere but Washington"
                 imaEnabled={true}
+                abTestParticipations={{}}
             />
         </div>
     );
@@ -228,6 +233,7 @@ export const WithOverlayAndPosterImage = (): JSX.Element => {
                 isMainMedia={false}
                 title="How Donald Trump’s broken promises failed Ohio"
                 imaEnabled={true}
+                abTestParticipations={{}}
             />
         </div>
     );
@@ -267,6 +273,7 @@ export const GiveConsent = (): JSX.Element => {
                     isMainMedia={false}
                     title="How to stop the spread of coronavirus"
                     imaEnabled={true}
+                    abTestParticipations={{}}
                 />
             </div>
         </>
@@ -296,6 +303,7 @@ export const Sticky = (): JSX.Element => {
                 isMainMedia={true}
                 title="Rayshard Brooks: US justice system treats us like 'animals'"
                 imaEnabled={true}
+                abTestParticipations={{}}
             />
             <div style={{ height: '1000px' }}></div>
         </div>
@@ -325,6 +333,7 @@ export const StickyMainMedia = (): JSX.Element => {
                 isMainMedia={true}
                 title="Rayshard Brooks: US justice system treats us like 'animals'"
                 imaEnabled={true}
+                abTestParticipations={{}}
             />
             <div style={{ height: '1000px' }}></div>
         </div>
@@ -350,6 +359,7 @@ export const DuplicateVideos = (): JSX.Element => {
                 width={800}
                 shouldStick={true}
                 imaEnabled={true}
+                abTestParticipations={{}}
             />
             <br />
             <YoutubeAtom
@@ -368,6 +378,7 @@ export const DuplicateVideos = (): JSX.Element => {
                 width={800}
                 shouldStick={true}
                 imaEnabled={true}
+                abTestParticipations={{}}
             />
         </div>
     );
@@ -394,6 +405,7 @@ export const MultipleStickyVideos = (): JSX.Element => {
                 isMainMedia={true}
                 title="Rayshard Brooks: US justice system treats us like 'animals'"
                 imaEnabled={true}
+                abTestParticipations={{}}
             />
             <YoutubeAtom
                 elementId="xyz-2"
@@ -413,6 +425,7 @@ export const MultipleStickyVideos = (): JSX.Element => {
                 isMainMedia={true}
                 title="Rayshard Brooks: US justice system treats us like 'animals'"
                 imaEnabled={true}
+                abTestParticipations={{}}
             />
             <YoutubeAtom
                 elementId="xyu"
@@ -432,6 +445,7 @@ export const MultipleStickyVideos = (): JSX.Element => {
                 isMainMedia={true}
                 title="Rayshard Brooks: US justice system treats us like 'animals'"
                 imaEnabled={true}
+                abTestParticipations={{}}
             />
         </div>
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1482,10 +1482,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/ab-core/-/ab-core-2.0.0.tgz#d8a9408d5a66ff1f8c684ed458c99517bbee15b1"
   integrity sha512-E5p6l0l37hY0GNFaZmA5/22TlVuavzlMHR3OeweD5eDcY2gB3nGgzPK/d3M67dkbDAJkGjB4a0W84Z5N2YScvQ==
 
-"@guardian/commercial-core@^4.24.0":
-  version "4.24.0"
-  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.24.0.tgz#4812d2a97f8b888092a4170624a0871742d83128"
-  integrity sha512-6ql4W6y0bx0GehSn7jNEkcn8DAoq3b/R9sfOCtbI952rouSaoKtIZcxKPK9PA9vSkWqkXF3hm9r/Ci2AKo+7gA==
+"@guardian/commercial-core@^4.25.0":
+  version "4.25.0"
+  resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.25.0.tgz#cbc1ab2aaff456a3dc20836b1520a4a29b3a75ec"
+  integrity sha512-EDFSiCtTAlXdu/WK8dCp+BO5TLIYeyZ4QGkYv2lNXJ7y2U3zFkyTipPHq2Ld9iOSyy2+TtcF3OPnXS4j1pJ7vA==
 
 "@guardian/consent-management-platform@^10":
   version "10.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1477,6 +1477,11 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@guardian/ab-core@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@guardian/ab-core/-/ab-core-2.0.0.tgz#d8a9408d5a66ff1f8c684ed458c99517bbee15b1"
+  integrity sha512-E5p6l0l37hY0GNFaZmA5/22TlVuavzlMHR3OeweD5eDcY2gB3nGgzPK/d3M67dkbDAJkGjB4a0W84Z5N2YScvQ==
+
 "@guardian/commercial-core@^4.24.0":
   version "4.24.0"
   resolved "https://registry.yarnpkg.com/@guardian/commercial-core/-/commercial-core-4.24.0.tgz#4812d2a97f8b888092a4170624a0871742d83128"


### PR DESCRIPTION
## What does this change?

Add `abTestParticipations` (aka client side participations) as a prop to `YoutubeAtom` and `YoutubeAtomPlayer` to pass to targeting for YouTube and YouTube IMA integrations.

This allows us target users in ab tests.

