### PR TITLE
Improve accessibility of Quiz atoms

### DIFF
--- a/.changeset/twenty-laws-double.md
+++ b/.changeset/twenty-laws-double.md
@@ -1,0 +1,5 @@
+---
+'@guardian/atoms-rendering': minor
+---
+
+Improve accessibility of Quiz atoms

--- a/src/KnowledgeQuiz.tsx
+++ b/src/KnowledgeQuiz.tsx
@@ -86,20 +86,22 @@ export const KnowledgeQuizAtom = ({
                     />
                 </div>
             )}
-            {questions.map((question, idx) => (
-                <Question
-                    key={question.id}
-                    id={question.id}
-                    number={idx + 1}
-                    text={question.text}
-                    imageUrl={question.imageUrl}
-                    imageAlt={question.imageAlt}
-                    answers={question.answers}
-                    quizSelection={quizSelection}
-                    setQuizSelection={setQuizSelection}
-                    theme={theme}
-                />
-            ))}
+            <ol>
+                {questions.map((question, idx) => (
+                    <Question
+                        key={question.id}
+                        id={question.id}
+                        number={idx + 1}
+                        text={question.text}
+                        imageUrl={question.imageUrl}
+                        imageAlt={question.imageAlt}
+                        answers={question.answers}
+                        quizSelection={quizSelection}
+                        setQuizSelection={setQuizSelection}
+                        theme={theme}
+                    />
+                ))}
+            </ol>
             {haveAllQuestionsBeenAnswered && (
                 <div data-testid="quiz-results-block-top">
                     <Result
@@ -148,7 +150,7 @@ export const Question = ({
     }, [selectedAnswerId, setQuizSelection, hasSubmitted, answers]);
 
     return (
-        <div
+        <li
             css={css`
                 ${theme === ArticleSpecial.Labs
                     ? textSans.medium()
@@ -220,7 +222,7 @@ export const Question = ({
                     </Button>
                 </div>
             </fieldset>
-        </div>
+        </li>
     );
 };
 

--- a/src/PersonalityQuiz.tsx
+++ b/src/PersonalityQuiz.tsx
@@ -176,31 +176,33 @@ export const PersonalityQuizAtom = ({
                     />
                 </div>
             )}
-            {questions.map((question, idx) => (
-                <PersonalityQuizAnswers
-                    key={question.id}
-                    id={question.id}
-                    questionNumber={idx + 1}
-                    text={question.text}
-                    imageUrl={question.imageUrl}
-                    imageAlt={question.imageAlt}
-                    answers={question.answers}
-                    updateSelectedAnswer={(selectedAnswerId: string) => {
-                        setHasMissingAnswers(false);
-                        setSelectedGlobalAnswers({
-                            ...selectedGlobalAnswers,
-                            [question.id]: selectedAnswerId,
-                        });
-                    }}
-                    globallySelectedAnswer={
-                        question.id in selectedGlobalAnswers
-                            ? selectedGlobalAnswers[question.id]
-                            : undefined
-                    }
-                    hasSubmittedAnswers={hasSubmittedAnswers}
-                    theme={theme}
-                />
-            ))}
+            <ol>
+                {questions.map((question, idx) => (
+                    <PersonalityQuizAnswers
+                        key={question.id}
+                        id={question.id}
+                        questionNumber={idx + 1}
+                        text={question.text}
+                        imageUrl={question.imageUrl}
+                        imageAlt={question.imageAlt}
+                        answers={question.answers}
+                        updateSelectedAnswer={(selectedAnswerId: string) => {
+                            setHasMissingAnswers(false);
+                            setSelectedGlobalAnswers({
+                                ...selectedGlobalAnswers,
+                                [question.id]: selectedAnswerId,
+                            });
+                        }}
+                        globallySelectedAnswer={
+                            question.id in selectedGlobalAnswers
+                                ? selectedGlobalAnswers[question.id]
+                                : undefined
+                        }
+                        hasSubmittedAnswers={hasSubmittedAnswers}
+                        theme={theme}
+                    />
+                ))}
+            </ol>
             {hasMissingAnswers && <MissingAnswers />}
             {hasSubmittedAnswers && topSelectedResult && (
                 <div data-testid="quiz-results-block-bottom">
@@ -297,39 +299,41 @@ const PersonalityQuizAnswers = ({
     }, [globallySelectedAnswer, setSelectedAnswers]);
 
     return (
-        <fieldset css={answersWrapperStyle(theme)}>
-            <legend
-                css={css`
-                    margin-bottom: 12px;
-                `}
-            >
-                <span
+        <li css={answersWrapperStyle(theme)}>
+            <fieldset>
+                <legend
                     css={css`
-                        padding-right: 12px;
+                        margin-bottom: 12px;
                     `}
                 >
-                    {questionNumber + '.'}
-                </span>
-                {text}
-            </legend>
-            {imageUrl && (
-                <img
-                    css={css`
-                        width: 100%;
-                    `}
-                    src={imageUrl}
-                    alt={imageAlt || ''}
+                    <span
+                        css={css`
+                            padding-right: 12px;
+                        `}
+                    >
+                        {questionNumber + '.'}
+                    </span>
+                    {text}
+                </legend>
+                {imageUrl && (
+                    <img
+                        css={css`
+                            width: 100%;
+                        `}
+                        src={imageUrl}
+                        alt={imageAlt || ''}
+                    />
+                )}
+                <AnswersGroup
+                    hasSubmittedAnswers={hasSubmittedAnswers}
+                    questionId={questionId}
+                    answers={answers}
+                    selectedAnswer={selectedAnswer}
+                    setSelectedAnswers={setSelectedAnswers}
+                    theme={theme}
                 />
-            )}
-            <AnswersGroup
-                hasSubmittedAnswers={hasSubmittedAnswers}
-                questionId={questionId}
-                answers={answers}
-                selectedAnswer={selectedAnswer}
-                setSelectedAnswers={setSelectedAnswers}
-                theme={theme}
-            />
-        </fieldset>
+            </fieldset>
+        </li>
     );
 };
 


### PR DESCRIPTION
## What does this change?

Improves the accesibility of our quiz atoms by wrapping the questions in a list using an `ol` and `li` tags.

This helps keyboard and screen-reader users to understand the hierarchy better and move quicker between the questions.

## Why?

Part of https://github.com/guardian/dotcom-rendering/issues/5065

For full fix, this package needs to be updated in `dotcom-rendering`.