### PR TITLE
Make peer deps optional

### DIFF
--- a/.changeset/chilly-pots-drive.md
+++ b/.changeset/chilly-pots-drive.md
@@ -1,0 +1,5 @@
+---
+'@guardian/atoms-rendering': patch
+---
+
+Make commercial core and CMP optional peer deps

--- a/package.json
+++ b/package.json
@@ -154,6 +154,14 @@
         "react-dom": "^17.0.1",
         "typescript": "^4.8.4"
     },
+    "peerDependenciesMeta": {
+        "@guardian/commercial-core": {
+            "optional": true
+        },
+        "@guardian/consent-management-platform": {
+            "optional": true
+        }
+    },
     "publishConfig": {
         "access": "public"
     }


### PR DESCRIPTION
## What does this change?

Makes `@guardian/commercial-core` and `@guardian/consent-management-platform` optional peer dependencies as they are required in DCR but not Apps-Rendering.